### PR TITLE
Fixes .zip Release Directory Structure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
           rm -rf dist
           npm run build_ff
           (cd dist && zip -r ../extension-firefox.zip .)
-          zip -r extension-firefox.zip dist/*
 
       - uses: "marvinpinto/action-automatic-releases@v1.2.1"
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,11 @@ jobs:
         run: |
           npm install
           npm run build
-          zip -r extension-chrome.zip dist
+          (cd dist && zip -r ../extension-chrome.zip .)
           rm -rf dist
           npm run build_ff
-          zip -r extension-firefox.zip dist
+          (cd dist && zip -r ../extension-firefox.zip .)
+          zip -r extension-firefox.zip dist/*
 
       - uses: "marvinpinto/action-automatic-releases@v1.2.1"
         with:


### PR DESCRIPTION
Currently the inner zip structure is:

* `dist`
  * `src`
  * `raw`
  * etc...

However, we need the contents of `dist` to be at the root of the zip in order to install the extension. This PR fixes this up.