### PR TITLE
Improves Trade Ping Timing Reliability

### DIFF
--- a/src/lib/alarms/setup.ts
+++ b/src/lib/alarms/setup.ts
@@ -24,8 +24,8 @@ export async function registerTradeAlarmIfPossible() {
     const alarm = await chrome.alarms.get(PING_CSFLOAT_TRADE_STATUS_ALARM_NAME);
 
     const hasAlarmWithOutdatedTimer =
-        (alarm?.periodInMinutes && alarm.periodInMinutes > 3) ||
-        (alarm.scheduledTime && alarm.scheduledTime > Date.now() + 10 * 60 * 1000); // Alarm scheduled more than 10 minutes in the future (can be caused by bad system clock)
+        (alarm?.periodInMinutes && alarm?.periodInMinutes > 3) ||
+        (alarm?.scheduledTime && alarm?.scheduledTime > Date.now() + 10 * 60 * 1000); // Alarm scheduled more than 10 minutes in the future (can be caused by bad system clock)
 
     if (!alarm || hasAlarmWithOutdatedTimer) {
         await chrome.alarms.create(PING_CSFLOAT_TRADE_STATUS_ALARM_NAME, {

--- a/src/lib/alarms/setup.ts
+++ b/src/lib/alarms/setup.ts
@@ -23,9 +23,13 @@ export async function registerTradeAlarmIfPossible() {
 
     const alarm = await chrome.alarms.get(PING_CSFLOAT_TRADE_STATUS_ALARM_NAME);
 
-    if (!alarm) {
+    const hasAlarmWithOutdatedTimer =
+        (alarm?.periodInMinutes && alarm.periodInMinutes > 3) ||
+        (alarm.scheduledTime && alarm.scheduledTime > Date.now() + 10 * 60 * 1000); // Alarm scheduled more than 10 minutes in the future (can be caused by bad system clock)
+
+    if (!alarm || hasAlarmWithOutdatedTimer) {
         await chrome.alarms.create(PING_CSFLOAT_TRADE_STATUS_ALARM_NAME, {
-            periodInMinutes: 5,
+            periodInMinutes: 3,
             delayInMinutes: 1,
         });
     }


### PR DESCRIPTION
* Makes default period 3 minutes instead of 5 minutes
* Re-schedules the alarm if the time is set too far into the future (possible if the user was shifting their system clock back and forth from the future), fixes #221