### PR TITLE
Restricts Inventory Picker If Previously Sent Non-Active Offer

### DIFF
--- a/src/lib/components/trade_offer/auto_fill.ts
+++ b/src/lib/components/trade_offer/auto_fill.ts
@@ -304,7 +304,9 @@ export class AutoFill extends FloatElement {
 
         const tradesToBuyer = this.pendingTradesResponse.trades.filter((e) => e.buyer_id === UserThem?.strSteamId);
 
-        const tradesWithoutOffersToBuyer = tradesToBuyer.filter((e) => !e.steam_offer?.state || !e.steam_offer?.id);
+        const tradesWithoutOffersToBuyer = tradesToBuyer.filter(
+            (e) => !e.steam_offer?.state || !e.steam_offer?.id || ![2, 3].includes(e.steam_offer?.state) // 2, 3 correspond to "active" and "accepted" trade offers
+        );
         if (tradesWithoutOffersToBuyer.length > 0 || hasQueryParameter('autofill')) {
             // Disable them being able to select random items from their inventory (ensure asset IDs match up)
             this.disableInventoryPicker();


### PR DESCRIPTION
For example:
* User creates offer for commodity item X called A
* User _also_ uses another marketplace such that it sends asset X to a different user
* Trade offer A is now invalidated

Previously, the extension wouldn't restrict the inventory picker, so the user could ignore the warnings and override the system more easily. We now will block the picker if there is also no "active" offer to the buyer for that item.