### PR TITLE
Saves Tokens in Local Storage instead of Sync

### DIFF
--- a/src/lib/storage/store.ts
+++ b/src/lib/storage/store.ts
@@ -2,12 +2,16 @@ import {DynamicStorageKey, StorageKey} from './keys';
 
 class Store {
     // Prefer to use sync storage if possible
-    get storage(): chrome.storage.SyncStorageArea | chrome.storage.LocalStorageArea {
+    get defaultStorageLayer(): chrome.storage.SyncStorageArea | chrome.storage.LocalStorageArea {
         return chrome.storage.sync ? chrome.storage.sync : chrome.storage.local;
     }
 
-    async get<T>(key: StorageKey | DynamicStorageKey): Promise<T | null> {
-        const a = await this.storage.get(key);
+    // getWithStorage using a specified storage layer
+    async getWithStorage<T>(
+        storage: chrome.storage.SyncStorageArea | chrome.storage.LocalStorageArea,
+        key: StorageKey | DynamicStorageKey
+    ): Promise<T | null> {
+        const a = await storage.get(key);
         if (!a || !(key in a)) {
             return null;
         }
@@ -20,12 +24,36 @@ class Store {
         }
     }
 
-    async set<T>(key: StorageKey | DynamicStorageKey, value: T): Promise<void> {
-        return this.storage.set({[key]: JSON.stringify(value)});
+    // get using the default storage layer
+    async get<T>(key: StorageKey | DynamicStorageKey): Promise<T | null> {
+        return this.getWithStorage(this.defaultStorageLayer, key);
     }
 
+    // setWithStorage using a specified storage layer
+    async setWithStorage<T>(
+        storage: chrome.storage.SyncStorageArea | chrome.storage.LocalStorageArea,
+        key: StorageKey | DynamicStorageKey,
+        value: T
+    ): Promise<void> {
+        return storage.set({[key]: JSON.stringify(value)});
+    }
+
+    // set using the default storage layer
+    async set<T>(key: StorageKey | DynamicStorageKey, value: T): Promise<void> {
+        return this.setWithStorage(this.defaultStorageLayer, key, value);
+    }
+
+    // removeWithStorage using a specified storage layer
+    async removeWithStorage(
+        storage: chrome.storage.SyncStorageArea | chrome.storage.LocalStorageArea,
+        key: StorageKey | DynamicStorageKey
+    ): Promise<void> {
+        return storage.remove([key]);
+    }
+
+    // remove using the default storage layer
     async remove(key: StorageKey | DynamicStorageKey): Promise<void> {
-        return this.storage.remove([key]);
+        return this.removeWithStorage(this.defaultStorageLayer, key);
     }
 }
 


### PR DESCRIPTION
Sync storage can have issues such as quota overflowing and connectivity issues.

We don't need the tokens to be on sync storage, so instead it should be on local.