### PR TITLE
Increases Amount of Trade History Fetched

### DIFF
--- a/src/lib/alarms/trade_history.ts
+++ b/src/lib/alarms/trade_history.ts
@@ -69,7 +69,7 @@ async function getTradeHistoryFromAPI(): Promise<TradeHistoryStatus[]> {
 
     // This only works if they have granted permission for https://api.steampowered.com
     const resp = await fetch(
-        `https://api.steampowered.com/IEconService/GetTradeHistory/v1/?access_token=${accessToken}&max_trades=200`,
+        `https://api.steampowered.com/IEconService/GetTradeHistory/v1/?access_token=${accessToken}&max_trades=100`,
         {
             credentials: 'include',
         }

--- a/src/lib/alarms/trade_history.ts
+++ b/src/lib/alarms/trade_history.ts
@@ -69,7 +69,7 @@ async function getTradeHistoryFromAPI(): Promise<TradeHistoryStatus[]> {
 
     // This only works if they have granted permission for https://api.steampowered.com
     const resp = await fetch(
-        `https://api.steampowered.com/IEconService/GetTradeHistory/v1/?access_token=${accessToken}&max_trades=50`,
+        `https://api.steampowered.com/IEconService/GetTradeHistory/v1/?access_token=${accessToken}&max_trades=200`,
         {
             credentials: 'include',
         }


### PR DESCRIPTION
Some users make many trades in a short span of time (ie. <1d) without having their main "extension" computer on for a long duration.

Increase the amount of trade history we're willing to sift through for update pings.