### PR TITLE
Auto-Cancel Unconfirmed Trade Offers for CSFloat Sales

### DIFF
--- a/src/lib/alarms/csfloat_trade_pings.ts
+++ b/src/lib/alarms/csfloat_trade_pings.ts
@@ -1,7 +1,7 @@
 import {Trade} from '../types/float_market';
 import {FetchPendingTrades} from '../bridge/handlers/fetch_pending_trades';
 import {pingTradeHistory} from './trade_history';
-import {pingCancelTrades, pingSentTradeOffers} from './trade_offer';
+import {cancelUnconfirmedTradeOffers, pingCancelTrades, pingSentTradeOffers} from './trade_offer';
 import {HasPermissions} from '../bridge/handlers/has_permissions';
 import {PingExtensionStatus} from '../bridge/handlers/ping_extension_status';
 import {AccessToken, getAccessToken} from './access_token';
@@ -71,6 +71,12 @@ interface UpdateErrors {
 
 async function pingUpdates(pendingTrades: Trade[]): Promise<UpdateErrors> {
     const errors: UpdateErrors = {};
+
+    try {
+        await cancelUnconfirmedTradeOffers(pendingTrades);
+    } catch (e) {
+        console.error(`failed to cancel unconfirmed trade offers`, e);
+    }
 
     try {
         await pingTradeHistory(pendingTrades);

--- a/src/lib/types/float_market.ts
+++ b/src/lib/types/float_market.ts
@@ -84,6 +84,7 @@ export enum TradeState {
 export interface SteamOffer {
     id: string;
     state: TradeOfferState;
+    sent_at: string;
 }
 
 export interface Trade {


### PR DESCRIPTION
Helps prevent the user from sending a trade offer _way after_ the sale has already failed (since they didn't confirm the trade offer on time).