### PR TITLE
Visualize Item Floats in a Floatbar (Market + Inventory)

### DIFF
--- a/src/lib/components/inventory/selected_item_info.ts
+++ b/src/lib/components/inventory/selected_item_info.ts
@@ -133,7 +133,7 @@ export class SelectedItemInfo extends FloatElement {
     }
 
     renderFloatBar(): TemplateResult<1> {
-        if (!this.itemInfo || !(this.itemInfo.floatvalue > 0)) {
+        if (!this.itemInfo || !this.itemInfo.floatvalue) {
             return html``;
         }
 

--- a/src/lib/components/inventory/selected_item_info.ts
+++ b/src/lib/components/inventory/selected_item_info.ts
@@ -52,6 +52,28 @@ export class SelectedItemInfo extends FloatElement {
                 color: #ebebeb;
                 text-decoration: none;
             }
+
+            .market-float-bar-container {
+                position: relative;
+                width: 100%;
+                height: 8px; 
+                margin: 5px 0;
+            }
+
+            .market-float-bar-marker {
+                position: absolute; 
+                background-color: #d9d9d9; 
+                width: 3px;
+                top: -3px;
+                height: 14px;
+                border-radius: 4px;
+            }
+
+            .market-float-bar {
+                display: inline-block; 
+                vertical-align: top; 
+                height: 100%; 
+            }
         `,
     ];
 
@@ -101,6 +123,7 @@ export class SelectedItemInfo extends FloatElement {
         const containerChildren: TemplateResult[] = [];
 
         if (isSkin(this.asset.description) && this.itemInfo) {
+            containerChildren.push(this.renderFloatBar());
             containerChildren.push(
                 html`<div>Float: ${this.itemInfo.floatvalue.toFixed(14)} ${renderClickableRank(this.itemInfo)}</div>`
             );
@@ -128,6 +151,40 @@ export class SelectedItemInfo extends FloatElement {
         }
 
         return html` <div class="container">${containerChildren}</div> `;
+    }
+
+    renderFloatBar(): TemplateResult<1> {
+        if (!this.itemInfo) {
+            return html``;
+        }
+        const itemInfo = this.itemInfo;
+        const left = (this.itemInfo.min * 100).toFixed(0);
+        const width = ((this.itemInfo.max - this.itemInfo.min) * 100).toFixed(0);
+        const markerLeft = (100 * this.itemInfo.floatvalue / (this.itemInfo.max - this.itemInfo.min)).toFixed(2);
+
+        let dynamicWidth = (this.itemInfo.max - this.itemInfo.min) * 100;
+        const floatConditions = [
+            { min: 0, max: 6, color: 'green' },
+            { min: 6, max: 15, color: '#18a518' },
+            { min: 15, max: 38, color: '#9acd32' },
+            { min: 38, max: 45, color: '#cd5c5c' },
+            { min: 45, max: 100, color: '#f92424' },
+        ];
+
+        return html`
+            <div class="market-float-bar-container" style="left: ${left}%; width: ${width}%;">
+                <div class="market-float-bar-marker" style="left: calc(${markerLeft}% - 2px);"></div>
+                <div style="height: 100%; border-radius: 4px; overflow: hidden">
+                    ${floatConditions.map(cond => {
+                        if (cond.max > (itemInfo.max * 100)) {
+                            return html`<div class="market-float-bar" style="width: 0%;"></div>`; 
+                        } else {
+                            return html`<div class="market-float-bar" style="width: ${(cond.max - cond.min) * 100 / dynamicWidth}%; background-color: ${cond.min < itemInfo.min ? "none" : cond.color};"></div>`;
+                        }
+                    })}
+                </div>
+            </div>
+        `;
     }
 
     renderFloatMarketListing(): TemplateResult<1> {

--- a/src/lib/components/inventory/selected_item_info.ts
+++ b/src/lib/components/inventory/selected_item_info.ts
@@ -18,6 +18,7 @@ import {Observe} from '../../utils/observers';
 import {FetchStallResponse} from '../../bridge/handlers/fetch_stall';
 import {gStallFetcher} from '../../services/stall_fetcher';
 import {Contract} from '../../types/float_market';
+import '../../ui/floatbar';
 
 /**
  * Why do we bind to iteminfo0 AND iteminfo1?
@@ -51,28 +52,6 @@ export class SelectedItemInfo extends FloatElement {
                 align-items: center;
                 color: #ebebeb;
                 text-decoration: none;
-            }
-
-            .market-float-bar-container {
-                position: relative;
-                width: 100%;
-                height: 8px; 
-                margin: 5px 0;
-            }
-
-            .market-float-bar-marker {
-                position: absolute; 
-                background-color: #d9d9d9; 
-                width: 3px;
-                top: -3px;
-                height: 14px;
-                border-radius: 4px;
-            }
-
-            .market-float-bar {
-                display: inline-block; 
-                vertical-align: top; 
-                height: 100%; 
             }
         `,
     ];
@@ -157,33 +136,13 @@ export class SelectedItemInfo extends FloatElement {
         if (!this.itemInfo) {
             return html``;
         }
-        const itemInfo = this.itemInfo;
-        const left = (this.itemInfo.min * 100).toFixed(0);
-        const width = ((this.itemInfo.max - this.itemInfo.min) * 100).toFixed(0);
-        const markerLeft = (100 * this.itemInfo.floatvalue / (this.itemInfo.max - this.itemInfo.min)).toFixed(2);
-
-        let dynamicWidth = (this.itemInfo.max - this.itemInfo.min) * 100;
-        const floatConditions = [
-            { min: 0, max: 6, color: 'green' },
-            { min: 6, max: 15, color: '#18a518' },
-            { min: 15, max: 38, color: '#9acd32' },
-            { min: 38, max: 45, color: '#cd5c5c' },
-            { min: 45, max: 100, color: '#f92424' },
-        ];
-
+        
         return html`
-            <div class="market-float-bar-container" style="left: ${left}%; width: ${width}%;">
-                <div class="market-float-bar-marker" style="left: calc(${markerLeft}% - 2px);"></div>
-                <div style="height: 100%; border-radius: 4px; overflow: hidden">
-                    ${floatConditions.map(cond => {
-                        if (cond.max > (itemInfo.max * 100)) {
-                            return html`<div class="market-float-bar" style="width: 0%;"></div>`; 
-                        } else {
-                            return html`<div class="market-float-bar" style="width: ${(cond.max - cond.min) * 100 / dynamicWidth}%; background-color: ${cond.min < itemInfo.min ? "none" : cond.color};"></div>`;
-                        }
-                    })}
-                </div>
-            </div>
+            <float-bar
+                float=${this.itemInfo.floatvalue}
+                minFloat=${this.itemInfo.min}
+                maxFloat=${this.itemInfo.max}>
+            </float-bar>
         `;
     }
 

--- a/src/lib/components/inventory/selected_item_info.ts
+++ b/src/lib/components/inventory/selected_item_info.ts
@@ -133,7 +133,7 @@ export class SelectedItemInfo extends FloatElement {
     }
 
     renderFloatBar(): TemplateResult<1> {
-        if (!this.itemInfo) {
+        if (!this.itemInfo || !(this.itemInfo.floatvalue > 0)) {
             return html``;
         }
 

--- a/src/lib/components/inventory/selected_item_info.ts
+++ b/src/lib/components/inventory/selected_item_info.ts
@@ -136,12 +136,9 @@ export class SelectedItemInfo extends FloatElement {
         if (!this.itemInfo) {
             return html``;
         }
-        
+
         return html`
-            <float-bar
-                float=${this.itemInfo.floatvalue}
-                minFloat=${this.itemInfo.min}
-                maxFloat=${this.itemInfo.max}>
+            <float-bar float=${this.itemInfo.floatvalue} minFloat=${this.itemInfo.min} maxFloat=${this.itemInfo.max}>
             </float-bar>
         `;
     }

--- a/src/lib/components/market/item_row_wrapper.ts
+++ b/src/lib/components/market/item_row_wrapper.ts
@@ -1,4 +1,4 @@
-import {css, html, nothing} from 'lit';
+import {css, html, nothing, TemplateResult} from 'lit';
 
 import {state} from 'lit/decorators.js';
 import {CustomElement, InjectAppend, InjectionMode} from '../injectors';
@@ -13,6 +13,7 @@ import {gFilterService} from '../../services/filter';
 import {AppId, ContextId, Currency} from '../../types/steam_constants';
 import {defined} from '../../utils/checkers';
 import {pickTextColour} from '../../utils/colours';
+import '../../ui/floatbar';
 
 @CustomElement()
 @InjectAppend('#searchResultsRows .market_listing_row .market_listing_item_name_block', InjectionMode.CONTINUOUS)
@@ -22,6 +23,7 @@ export class ItemRowWrapper extends FloatElement {
         css`
             .float-row-wrapper {
                 margin-bottom: 5px;
+                max-width: max(50%, 400px);
             }
         `,
     ];
@@ -158,6 +160,7 @@ export class ItemRowWrapper extends FloatElement {
 
             return html`
                 <div class="float-row-wrapper">
+                    ${this.renderFloatBar()}
                     Float: ${this.itemInfo.floatvalue.toFixed(14)} ${renderClickableRank(this.itemInfo)}<br />
                     Paint Seed:
                     ${formatSeed(this.itemInfo)}${fadePercentage !== undefined
@@ -177,5 +180,20 @@ export class ItemRowWrapper extends FloatElement {
         } else {
             return html`<div>Loading...</div>`;
         }
+    }
+
+    
+    renderFloatBar(): TemplateResult<1> {
+        if (!this.itemInfo) {
+            return html``;
+        }
+        
+        return html`
+            <float-bar
+                float=${this.itemInfo.floatvalue}
+                minFloat=${this.itemInfo.min}
+                maxFloat=${this.itemInfo.max}>
+            </float-bar>
+        `;
     }
 }

--- a/src/lib/components/market/item_row_wrapper.ts
+++ b/src/lib/components/market/item_row_wrapper.ts
@@ -160,8 +160,9 @@ export class ItemRowWrapper extends FloatElement {
 
             return html`
                 <div class="float-row-wrapper">
-                    ${this.renderFloatBar()} Float: ${this.itemInfo.floatvalue.toFixed(14)}
-                    ${renderClickableRank(this.itemInfo)}<br />
+                    ${this.renderFloatBar()}
+                    <span> Float: ${this.itemInfo.floatvalue.toFixed(14)} ${renderClickableRank(this.itemInfo)} </span>
+                    <br />
                     Paint Seed:
                     ${formatSeed(this.itemInfo)}${fadePercentage !== undefined
                         ? html`<br />

--- a/src/lib/components/market/item_row_wrapper.ts
+++ b/src/lib/components/market/item_row_wrapper.ts
@@ -160,8 +160,8 @@ export class ItemRowWrapper extends FloatElement {
 
             return html`
                 <div class="float-row-wrapper">
-                    ${this.renderFloatBar()}
-                    Float: ${this.itemInfo.floatvalue.toFixed(14)} ${renderClickableRank(this.itemInfo)}<br />
+                    ${this.renderFloatBar()} Float: ${this.itemInfo.floatvalue.toFixed(14)}
+                    ${renderClickableRank(this.itemInfo)}<br />
                     Paint Seed:
                     ${formatSeed(this.itemInfo)}${fadePercentage !== undefined
                         ? html`<br />
@@ -182,17 +182,13 @@ export class ItemRowWrapper extends FloatElement {
         }
     }
 
-    
     renderFloatBar(): TemplateResult<1> {
         if (!this.itemInfo) {
             return html``;
         }
-        
+
         return html`
-            <float-bar
-                float=${this.itemInfo.floatvalue}
-                minFloat=${this.itemInfo.min}
-                maxFloat=${this.itemInfo.max}>
+            <float-bar float=${this.itemInfo.floatvalue} minFloat=${this.itemInfo.min} maxFloat=${this.itemInfo.max}>
             </float-bar>
         `;
     }

--- a/src/lib/ui/floatbar.ts
+++ b/src/lib/ui/floatbar.ts
@@ -56,9 +56,9 @@ export class FloatBar extends LitElement {
     }
 
     render() {
-        const left = (this.minFloat * 100).toFixed(0);
+        const left = this.minFloatPercentage.toFixed(0);
         const markerLeft = (((this.float - this.minFloat) * 100) / (this.maxFloat - this.minFloat)).toFixed(3);
-        const dynamicWidth = (this.maxFloat - this.minFloat) * 100;
+        const dynamicWidth = this.maxFloatPercentage - this.minFloatPercentage;
 
         const getConditionWidth = (condMin: number, condMax: number) => {
             return (

--- a/src/lib/ui/floatbar.ts
+++ b/src/lib/ui/floatbar.ts
@@ -1,4 +1,4 @@
-import {LitElement, html, css, TemplateResult} from 'lit';
+import {LitElement, html, css} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
 @customElement('float-bar')
@@ -31,10 +31,10 @@ export class FloatBar extends LitElement {
             opacity: 0.8;
         }
 
-        .market-float-bar:not([style*='background-color: transparent']):first-of-type {
+        .market-float-bar:first-of-type {
             border-radius: 4px 0 0 4px;
         }
-        .market-float-bar:not([style*='background-color: transparent']):last-of-type {
+        .market-float-bar:last-of-type {
             border-radius: 0 4px 4px 0;
         }
     `;
@@ -47,10 +47,27 @@ export class FloatBar extends LitElement {
         {min: 45, max: 100, color: '#f92424'},
     ];
 
-    render(): TemplateResult {
+    get minFloatPercentage(): number {
+        return this.minFloat * 100;
+    }
+
+    get maxFloatPercentage(): number {
+        return this.maxFloat * 100;
+    }
+
+    render() {
         const left = (this.minFloat * 100).toFixed(0);
         const markerLeft = (((this.float - this.minFloat) * 100) / (this.maxFloat - this.minFloat)).toFixed(3);
         const dynamicWidth = (this.maxFloat - this.minFloat) * 100;
+
+        const getConditionWidth = (condMin: number, condMax: number) => {
+            return (
+                Math.max(
+                    0,
+                    (Math.min(condMax, this.maxFloatPercentage) - Math.max(condMin, this.minFloatPercentage)) * 100
+                ) / dynamicWidth
+            );
+        };
 
         return html`
             <div class="market-float-bar-container" style="left: ${left}%; width: ${dynamicWidth.toFixed(2)}%;">
@@ -59,10 +76,10 @@ export class FloatBar extends LitElement {
                         (cond) => html`
                             <div
                                 class="market-float-bar"
-                                style="width: ${((Math.min(cond.max, this.maxFloat * 100) -
-                                    Math.max(cond.min, this.minFloat * 100)) *
-                                    100) /
-                                dynamicWidth}%; background-color: ${cond.color};"
+                                style="width: ${getConditionWidth(
+                                    cond.min,
+                                    cond.max
+                                )}%; background-color: ${cond.color};"
                             ></div>
                         `
                     )}

--- a/src/lib/ui/floatbar.ts
+++ b/src/lib/ui/floatbar.ts
@@ -1,42 +1,42 @@
-import { LitElement, html, css, TemplateResult } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import {LitElement, html, css, TemplateResult} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
 
 @customElement('float-bar')
 export class FloatBar extends LitElement {
-    @property({ type: Number }) float!: number;
-    @property({ type: Number }) minFloat = 0;
-    @property({ type: Number }) maxFloat = 1;
+    @property({type: Number}) float!: number;
+    @property({type: Number}) minFloat = 0;
+    @property({type: Number}) maxFloat = 1;
 
     static styles = css`
-            .market-float-bar-container {
-                position: relative;
-                width: 100%;
-                height: 8px;
-                margin: 5px 0;
-            }
+        .market-float-bar-container {
+            position: relative;
+            width: 100%;
+            height: 8px;
+            margin: 5px 0;
+        }
 
-            .market-float-bar-marker {
-                position: absolute;
-                background-color: #d9d9d9;
-                width: 3px;
-                top: -3px;
-                height: 14px;
-                border-radius: 4px;
-            }
+        .market-float-bar-marker {
+            position: absolute;
+            background-color: #d9d9d9;
+            width: 3px;
+            top: -3px;
+            height: 14px;
+            border-radius: 4px;
+        }
 
-            .market-float-bar {
-                display: inline-block;
-                vertical-align: top;
-                height: 100%;
-                opacity: 0.8;
-            }
+        .market-float-bar {
+            display: inline-block;
+            vertical-align: top;
+            height: 100%;
+            opacity: 0.8;
+        }
 
-            .market-float-bar:not([style*='background-color: transparent']):first-of-type {
-                border-radius: 4px 0 0 4px;
-            }
-            .market-float-bar:not([style*='background-color: transparent']):last-of-type {
-                border-radius: 0 4px 4px 0;
-            }
+        .market-float-bar:not([style*='background-color: transparent']):first-of-type {
+            border-radius: 4px 0 0 4px;
+        }
+        .market-float-bar:not([style*='background-color: transparent']):last-of-type {
+            border-radius: 0 4px 4px 0;
+        }
     `;
 
     private readonly floatConditions = [
@@ -49,21 +49,23 @@ export class FloatBar extends LitElement {
 
     render(): TemplateResult {
         const left = (this.minFloat * 100).toFixed(0);
-        const markerLeft = ((this.float - this.minFloat) * 100 / (this.maxFloat - this.minFloat)).toFixed(3);
+        const markerLeft = (((this.float - this.minFloat) * 100) / (this.maxFloat - this.minFloat)).toFixed(3);
         const dynamicWidth = (this.maxFloat - this.minFloat) * 100;
 
         return html`
             <div class="market-float-bar-container" style="left: ${left}%; width: ${dynamicWidth.toFixed(2)}%;">
                 <div style="height: 100%; border-radius: 4px; overflow: hidden; font-size: 0;">
-                    ${this.floatConditions.map((cond) => html`
-                        <div
-                            class="market-float-bar"
-                            style="width: ${((Math.min(cond.max, this.maxFloat * 100) -
-                                Math.max(cond.min, this.minFloat * 100)) *
-                                100) /
-                            dynamicWidth}%; background-color: ${cond.color};">
-                        </div>
-                    `)}
+                    ${this.floatConditions.map(
+                        (cond) => html`
+                            <div
+                                class="market-float-bar"
+                                style="width: ${((Math.min(cond.max, this.maxFloat * 100) -
+                                    Math.max(cond.min, this.minFloat * 100)) *
+                                    100) /
+                                dynamicWidth}%; background-color: ${cond.color};"
+                            ></div>
+                        `
+                    )}
                 </div>
                 <div class="market-float-bar-marker" style="left: calc(${markerLeft}% - 2px);"></div>
             </div>

--- a/src/lib/ui/floatbar.ts
+++ b/src/lib/ui/floatbar.ts
@@ -1,0 +1,72 @@
+import { LitElement, html, css, TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+@customElement('float-bar')
+export class FloatBar extends LitElement {
+    @property({ type: Number }) float!: number;
+    @property({ type: Number }) minFloat = 0;
+    @property({ type: Number }) maxFloat = 1;
+
+    static styles = css`
+            .market-float-bar-container {
+                position: relative;
+                width: 100%;
+                height: 8px;
+                margin: 5px 0;
+            }
+
+            .market-float-bar-marker {
+                position: absolute;
+                background-color: #d9d9d9;
+                width: 3px;
+                top: -3px;
+                height: 14px;
+                border-radius: 4px;
+            }
+
+            .market-float-bar {
+                display: inline-block;
+                vertical-align: top;
+                height: 100%;
+                opacity: 0.8;
+            }
+
+            .market-float-bar:not([style*='background-color: transparent']):first-of-type {
+                border-radius: 4px 0 0 4px;
+            }
+            .market-float-bar:not([style*='background-color: transparent']):last-of-type {
+                border-radius: 0 4px 4px 0;
+            }
+    `;
+
+    private readonly floatConditions = [
+        {min: 0, max: 7, color: 'green'},
+        {min: 7, max: 15, color: '#18a518'},
+        {min: 15, max: 38, color: '#9acd32'},
+        {min: 38, max: 45, color: '#cd5c5c'},
+        {min: 45, max: 100, color: '#f92424'},
+    ];
+
+    render(): TemplateResult {
+        const left = (this.minFloat * 100).toFixed(0);
+        const markerLeft = ((this.float - this.minFloat) * 100 / (this.maxFloat - this.minFloat)).toFixed(3);
+        const dynamicWidth = (this.maxFloat - this.minFloat) * 100;
+
+        return html`
+            <div class="market-float-bar-container" style="left: ${left}%; width: ${dynamicWidth.toFixed(2)}%;">
+                <div style="height: 100%; border-radius: 4px; overflow: hidden; font-size: 0;">
+                    ${this.floatConditions.map((cond) => html`
+                        <div
+                            class="market-float-bar"
+                            style="width: ${((Math.min(cond.max, this.maxFloat * 100) -
+                                Math.max(cond.min, this.minFloat * 100)) *
+                                100) /
+                            dynamicWidth}%; background-color: ${cond.color};">
+                        </div>
+                    `)}
+                </div>
+                <div class="market-float-bar-marker" style="left: calc(${markerLeft}% - 2px);"></div>
+            </div>
+        `;
+    }
+}


### PR DESCRIPTION
## Motivation

Floats can be a pretty confusing concept at first glance. To illustrate the basics of low/high-floats, we want to introduce a float-bar, which visualizes an item's float according to all possible values in a colored bar.
Solves #9.

## Description

This PR contains a new float-bar component:
- New UI-Component: `FloatBar` (LitElement) inspired by the floatbar on the CSFloat website:
  - Can be re-used as HTML-element in any component: `<float-bar></float-bar>`
  - Bar is limited according to provided min/max-float values
  - White marker at the actual item float
  - Opacity of `0.8` to adjust color-spectrum to Steam's "dark theme"
- Adds `FloatBar` to inventory-page
- Adds `FloatBar` to market-page and limits its width in a responsive manner

Possible follow-ups:
- [ ] Tooltip with more "details" such as the min/max floats in text format
- [ ] Actual Float as "hover" above the float-marker

## Screenshots

Floatbar in the inventory:
![image](https://github.com/user-attachments/assets/58e2e49d-6993-4297-b657-45598f585dca)
Floatbar on the market:
![image](https://github.com/user-attachments/assets/9c1d6923-b212-4567-b0ef-79f6df6eb6cb)
Floatbar on the market (mobile):
![image](https://github.com/user-attachments/assets/79348058-f917-402d-beee-a7e950dce202)

