### PR TITLE
Add Versioning to Zip-Files in Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,17 +22,18 @@ jobs:
 
       - name: Build and compress
         run: |
+          TAG=${{ github.ref_name }}
           npm install
           npm run build
-          (cd dist && zip -r ../extension-chrome.zip .)
+          (cd dist && zip -r ../extension-${TAG}-chrome.zip .)
           rm -rf dist
           npm run build_ff
-          (cd dist && zip -r ../extension-firefox.zip .)
+          (cd dist && zip -r ../extension-${TAG}-firefox.zip .)
 
       - uses: "marvinpinto/action-automatic-releases@v1.2.1"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false
           files: |
-            extension-chrome.zip
-            extension-firefox.zip
+            extension-*-chrome.zip
+            extension-*-firefox.zip


### PR DESCRIPTION
## Motivation
Closes #270.

## Description

This PR adds versioning to the ZIP-files included in every release in the Github-repo via the tag of the release-commit.

Has been tested in my fork of this repo locally via [nektos/act](https://github.com/nektos/act) and with Github Actions in an exemplary fork release [v5.1.2](https://github.com/GODrums/csfloat-extension/releases/tag/v5.1.2):
![image](https://github.com/user-attachments/assets/720942d2-8357-46ac-97df-bed604f7a921)
