### PR TITLE
Fix: Steam Market Sticker Container

### DIFF
--- a/src/lib/components/market/helpers.ts
+++ b/src/lib/components/market/helpers.ts
@@ -111,7 +111,6 @@ export function inlineStickersAndKeychains(itemNameBlock: JQuery<Element>, itemI
     itemNameBlock.parent().find('.market_listing_row_action')?.parent().remove();
     // Remove Steam's stickers and keychains
     itemNameBlock.parent().find('.market_listing_row_details')?.remove();
-    
 
     if (itemNameBlock.find('.csfloat-stickers-container').length) {
         // Don't inline stickers if they're already inlined
@@ -147,4 +146,3 @@ export function inlineEasyInspect(itemImgContainer: JQuery<Element>, inspectLink
         <a class="csfloat-easy-inspect" href="${inspectLink}">🔍</a>
     `);
 }
-

--- a/src/lib/components/market/helpers.ts
+++ b/src/lib/components/market/helpers.ts
@@ -107,6 +107,12 @@ function generateKeychainInlineHTML(itemInfo: ItemInfo, asset: rgAsset): string[
 export function inlineStickersAndKeychains(itemNameBlock: JQuery<Element>, itemInfo: ItemInfo, asset: rgAsset) {
     if (!itemNameBlock) return;
 
+    // Remove Steam's inspect button
+    itemNameBlock.parent().find('.market_listing_row_action')?.parent().remove();
+    // Remove Steam's stickers and keychains
+    itemNameBlock.parent().find('.market_listing_row_details')?.remove();
+    
+
     if (itemNameBlock.find('.csfloat-stickers-container').length) {
         // Don't inline stickers if they're already inlined
         return;
@@ -117,11 +123,16 @@ export function inlineStickersAndKeychains(itemNameBlock: JQuery<Element>, itemI
         return;
     }
 
+    const elementId = `listing_${itemInfo.m}_csfloat`;
+
     itemNameBlock.prepend(`
-        <div class="csfloat-stickers-container">
+        <div class="csfloat-stickers-container" id="${elementId}">
             ${blobs.reduce((acc, v) => acc + v, '')}
         </div>
     `);
+
+    // Add Steam's item popover on-hover
+    CreateItemHoverFromContainer(g_rgAssets, elementId, asset.appid, asset.contextid, asset.id, asset.amount);
 }
 
 /**
@@ -136,3 +147,4 @@ export function inlineEasyInspect(itemImgContainer: JQuery<Element>, inspectLink
         <a class="csfloat-easy-inspect" href="${inspectLink}">🔍</a>
     `);
 }
+

--- a/src/lib/components/market/helpers.ts
+++ b/src/lib/components/market/helpers.ts
@@ -88,7 +88,7 @@ function generateStickerInlineHTML(itemInfo: ItemInfo, asset: rgAsset): string[]
 function generateKeychainInlineHTML(itemInfo: ItemInfo, asset: rgAsset): string[] {
     const description = getKeychainDescription(itemInfo, asset);
 
-    if (!description || description.type !== 'html' || !description.value.includes('sticker')) {
+    if (!description || description.type !== 'html' || description.value.includes('sticker')) {
         return [];
     }
 

--- a/src/lib/components/market/item_row_wrapper.ts
+++ b/src/lib/components/market/item_row_wrapper.ts
@@ -141,14 +141,12 @@ export class ItemRowWrapper extends FloatElement {
             MarketCheckHash();
         }
 
-        
         // Make sure the parent containers can overflow
         const parentContainer = $J(this).parent();
         if (parentContainer) {
             parentContainer.css('overflow', 'visible');
             parentContainer.parent().css('overflow', 'visible');
         }
-
     }
 
     render() {
@@ -170,7 +168,9 @@ export class ItemRowWrapper extends FloatElement {
             return html`
                 <div class="float-row-wrapper">
                     ${this.renderFloatBar()}
-                    <span style="display: block;"> Float: ${this.itemInfo.floatvalue.toFixed(14)} ${renderClickableRank(this.itemInfo)} </span>
+                    <span style="display: block;">
+                        Float: ${this.itemInfo.floatvalue.toFixed(14)} ${renderClickableRank(this.itemInfo)}
+                    </span>
                     Paint Seed:
                     ${formatSeed(this.itemInfo)}${fadePercentage !== undefined
                         ? html`<br />

--- a/src/lib/components/market/item_row_wrapper.ts
+++ b/src/lib/components/market/item_row_wrapper.ts
@@ -140,6 +140,15 @@ export class ItemRowWrapper extends FloatElement {
             // dialogs opening.
             MarketCheckHash();
         }
+
+        
+        // Make sure the parent containers can overflow
+        const parentContainer = $J(this).parent();
+        if (parentContainer) {
+            parentContainer.css('overflow', 'visible');
+            parentContainer.parent().css('overflow', 'visible');
+        }
+
     }
 
     render() {
@@ -161,8 +170,7 @@ export class ItemRowWrapper extends FloatElement {
             return html`
                 <div class="float-row-wrapper">
                     ${this.renderFloatBar()}
-                    <span> Float: ${this.itemInfo.floatvalue.toFixed(14)} ${renderClickableRank(this.itemInfo)} </span>
-                    <br />
+                    <span style="display: block;"> Float: ${this.itemInfo.floatvalue.toFixed(14)} ${renderClickableRank(this.itemInfo)} </span>
                     Paint Seed:
                     ${formatSeed(this.itemInfo)}${fadePercentage !== undefined
                         ? html`<br />

--- a/src/lib/types/steam.d.ts
+++ b/src/lib/types/steam.d.ts
@@ -223,7 +223,7 @@ export type SteamAssets = {
     [appId in AppId]: {
         [contextId in ContextId]: {[assetId: string]: rgAsset};
     };
-}
+};
 
 // Declares globals available in the Steam Page Context
 declare global {
@@ -252,7 +252,14 @@ declare global {
     const MoveItemToTrade: (el: HTMLElement) => void; // Only populated on create offer pages
     const g_rgCurrentTradeStatus: CurrentTradeStatus;
     const ShowItemInventory: (appID: AppId, contextID: ContextId, AssetID?: number) => void;
-    const CreateItemHoverFromContainer: (g_rgAssets: SteamAssets, elementId: string, appid: AppId, contextid: string, id: string, amount: number) => void;
+    const CreateItemHoverFromContainer: (
+        g_rgAssets: SteamAssets,
+        elementId: string,
+        appid: AppId,
+        contextid: string,
+        id: string,
+        amount: number
+    ) => void;
 }
 
 export {};

--- a/src/lib/types/steam.d.ts
+++ b/src/lib/types/steam.d.ts
@@ -219,16 +219,18 @@ export interface TradeInventory {
     success: boolean;
 }
 
+export type SteamAssets = {
+    [appId in AppId]: {
+        [contextId in ContextId]: {[assetId: string]: rgAsset};
+    };
+}
+
 // Declares globals available in the Steam Page Context
 declare global {
     const $J: typeof $;
     const g_rgListingInfo: {[listingId: string]: ListingData};
     const g_rgWalletInfo: WalletInfo | undefined; // Not populated when user is signed-out
-    const g_rgAssets: {
-        [appId in AppId]: {
-            [contextId in ContextId]: {[assetId: string]: rgAsset};
-        };
-    };
+    const g_rgAssets: SteamAssets;
     const g_ActiveInventory: CInventory | undefined; // Only populated on Steam inventory pages
     const g_steamID: string;
     const g_oSearchResults: CAjaxPagingControls;
@@ -250,6 +252,7 @@ declare global {
     const MoveItemToTrade: (el: HTMLElement) => void; // Only populated on create offer pages
     const g_rgCurrentTradeStatus: CurrentTradeStatus;
     const ShowItemInventory: (appID: AppId, contextID: ContextId, AssetID?: number) => void;
+    const CreateItemHoverFromContainer: (g_rgAssets: SteamAssets, elementId: string, appid: AppId, contextid: string, id: string, amount: number) => void;
 }
 
 export {};


### PR DESCRIPTION
## Motivation

In today's update, Steam introduced a new inline display for stickers and charms. Since the extension has its own sticker/charm container, we have to solve the conflict and fix all alignments.

## Description

Since the extension's own container has more features, we want to adopt Steam's unique item popover while purging their new container in favor of ours:
- Remove the new "Inspect In Game"-button in favor of our own inspect-link on-hover on the item image
- Remove Steam's new sticker/charm container
- Fix alignment of floatbar and overflow of tooltip according to new structure
- Fix a bug where keychains did not get displayed because of an incorrect exit check
- Add item popover on-hover to the extension's sticker/charm container
![image](https://github.com/user-attachments/assets/0dcebded-2914-401b-a882-f77cf2783248)