### PR TITLE
Fix: Floatbar Overflow on Market Pages

### DIFF
--- a/src/lib/components/market/item_row_wrapper.ts
+++ b/src/lib/components/market/item_row_wrapper.ts
@@ -22,6 +22,7 @@ export class ItemRowWrapper extends FloatElement {
         ...FloatElement.styles,
         css`
             .float-row-wrapper {
+                display: inline-block;
                 margin-bottom: 5px;
                 max-width: max(50%, 400px);
             }

--- a/src/lib/components/market/item_row_wrapper.ts
+++ b/src/lib/components/market/item_row_wrapper.ts
@@ -24,7 +24,6 @@ export class ItemRowWrapper extends FloatElement {
             .float-row-wrapper {
                 display: inline-block;
                 margin-bottom: 5px;
-                max-width: max(50%, 400px);
             }
         `,
     ];


### PR DESCRIPTION
## Motivation

Fixes #281.

## Description

With the addition of the tooltip, we require our containers to use `overflow: visible` in order to display the the tooltip correctly.
This leads to the `ItemRowWrapper` overflowing into the sticker-container, which is not a part of the same shadow-root.


This PR fixes the issue by giving the main child of the Shadow-Root a `display: inline-block`, making sure the whole container stays within its boundaries.

Side-effect: the float-bar is now unable to dynamically adjust its size according to the parent system, meaning the maximum width will always be given by the width of the text (`Float: ...`) below.

## Screenshots
Example with float limits 0-1:
![Screenshot 2024-12-10 021828](https://github.com/user-attachments/assets/ab478226-bb76-461b-aec4-cf0edb0c376e)
Example with float limits 0.1-0.7:
![Screenshot 2024-12-10 021938](https://github.com/user-attachments/assets/8953fbd6-2f53-4ceb-b88f-d9b312b4a867)

