### PR TITLE
Fixes Unique Job ID Calc within CachedHandler

### DIFF
--- a/src/lib/bridge/wrappers/cached.ts
+++ b/src/lib/bridge/wrappers/cached.ts
@@ -16,8 +16,8 @@ class HandlerJob<Req> extends Job<WrappedRequest<Req>> {
 
     hashCode(): string {
         // Ensure deterministic stringification between two requests for the same
-        // properties
-        return stringify(this.data);
+        // properties. Do not cache based on the sender since it changes every request.
+        return stringify(this.req);
     }
 }
 


### PR DESCRIPTION
Previously it included the sender in the ID, however it seems like browsers such as Chrome have changing properties in this for each request.

Now it only caches based on the request data, tested locally using PR #283