### PR TITLE
Fix: Compatibility issues for Firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@types/cheerio": "^0.22.35"
             },
             "devDependencies": {
-                "@types/chrome": "^0.0.193",
+                "@types/chrome": "^0.0.300",
                 "@types/firefox-webext-browser": "^111.0.1",
                 "@types/jquery": "^3.5.14",
                 "@types/lodash": "^4.14.195",
@@ -259,10 +259,11 @@
             }
         },
         "node_modules/@types/chrome": {
-            "version": "0.0.193",
-            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.193.tgz",
-            "integrity": "sha512-R8C84oqvk8A8C8G1viBd8qLpDr86Y/jwD+KLgzUekbIT9RGds6a9GnlQyg8P7ltnGogTMHkiEQK0ZlcrvTeo3Q==",
+            "version": "0.0.300",
+            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.300.tgz",
+            "integrity": "sha512-vS5bUmNjMrbPut43Q8plS8GTAiJE+pBOxw1ovGC4LcwiGNKTithAH7TxhzHeX4wNq/FsaLj5KaW7riI0CgYjIg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/filesystem": "*",
                 "@types/har-format": "*"
@@ -3966,9 +3967,9 @@
             }
         },
         "@types/chrome": {
-            "version": "0.0.193",
-            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.193.tgz",
-            "integrity": "sha512-R8C84oqvk8A8C8G1viBd8qLpDr86Y/jwD+KLgzUekbIT9RGds6a9GnlQyg8P7ltnGogTMHkiEQK0ZlcrvTeo3Q==",
+            "version": "0.0.300",
+            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.300.tgz",
+            "integrity": "sha512-vS5bUmNjMrbPut43Q8plS8GTAiJE+pBOxw1ovGC4LcwiGNKTithAH7TxhzHeX4wNq/FsaLj5KaW7riI0CgYjIg==",
             "dev": true,
             "requires": {
                 "@types/filesystem": "*",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     },
     "homepage": "https://github.com/csfloat/extension#readme",
     "devDependencies": {
-        "@types/chrome": "^0.0.193",
+        "@types/chrome": "^0.0.300",
         "@types/firefox-webext-browser": "^111.0.1",
         "@types/jquery": "^3.5.14",
         "@types/lodash": "^4.14.195",

--- a/src/background.ts
+++ b/src/background.ts
@@ -5,6 +5,7 @@ import {alarmListener, registerTradeAlarmIfPossible} from './lib/alarms/setup';
 import {pingTradeStatus} from './lib/alarms/csfloat_trade_pings';
 import {gStore} from './lib/storage/store';
 import {StorageKey} from './lib/storage/keys';
+import {isFirefox} from './lib/utils/detect';
 
 function unifiedHandler(request: any, sender: MessageSender, sendResponse: (response?: any) => void) {
     Handle(request, sender)
@@ -66,3 +67,39 @@ async function checkTradeStatus() {
     }
 }
 checkTradeStatus();
+
+if (isFirefox()) {
+    // Need to manually update the rule to allow the extension to send trade offers
+    // Since Firefox IDs are random and we still want to scope it to only this extension
+    browser.declarativeNetRequest
+        .updateDynamicRules({
+            removeRuleIds: [1738196326],
+            addRules: [
+                {
+                    id: 1738196326,
+                    priority: 2,
+                    action: {
+                        type: 'modifyHeaders',
+                        requestHeaders: [
+                            {
+                                header: 'referer',
+                                operation: 'set',
+                                value: 'https://steamcommunity.com/tradeoffer/new',
+                            },
+                        ],
+                    },
+                    condition: {
+                        urlFilter: 'https://steamcommunity.com/tradeoffer/new/send',
+                        resourceTypes: ['xmlhttprequest'],
+                        initiatorDomains: [new URL(browser.runtime.getURL('')).hostname],
+                    },
+                },
+            ],
+        })
+        .then(() => {
+            console.log('[INFO] Successfully updated ruleset');
+        })
+        .catch((e) => {
+            console.error('[ERROR] Failed to update ruleset for Firefox');
+        });
+}

--- a/src/background.ts
+++ b/src/background.ts
@@ -25,7 +25,7 @@ function unifiedHandler(request: any, sender: MessageSender, sendResponse: (resp
         });
 }
 
-function requestPermissions(permissions: string[], origins: string[], sendResponse: any) {
+function requestPermissions(permissions: chrome.runtime.ManifestPermissions[], origins: string[], sendResponse: any) {
     chrome.permissions.request({permissions, origins}, (granted) => sendResponse(granted));
 
     return true;

--- a/src/lib/bridge/handlers/has_permissions.ts
+++ b/src/lib/bridge/handlers/has_permissions.ts
@@ -2,7 +2,7 @@ import {SimpleHandler} from './main';
 import {RequestType} from './types';
 
 export interface HasPermissionsRequest {
-    permissions: string[];
+    permissions: chrome.runtime.ManifestPermissions[];
     origins: string[];
 }
 
@@ -13,11 +13,10 @@ export interface HasPermissionsResponse {
 export const HasPermissions = new SimpleHandler<HasPermissionsRequest, HasPermissionsResponse>(
     RequestType.HAS_PERMISSIONS,
     async (req) => {
-        // @ts-ignore
-        const granted = (await chrome.permissions.contains({
+        const granted = await chrome.permissions.contains({
             permissions: req.permissions,
             origins: req.origins,
-        })) as boolean;
+        });
 
         return {
             granted,

--- a/src/lib/components/common/ui/steam-button.ts
+++ b/src/lib/components/common/ui/steam-button.ts
@@ -18,6 +18,9 @@ export class SteamButton extends FloatElement {
     @property({type: String})
     private type: ButtonType = ButtonType.GreenWhite;
 
+    @property({type: Boolean})
+    private disabled: boolean = false;
+
     static styles = [
         ...FloatElement.styles,
         css`
@@ -102,6 +105,10 @@ export class SteamButton extends FloatElement {
                 font-size: 12px;
                 line-height: 20px;
             }
+
+            .btn_disabled {
+                cursor: default;
+            }
         `,
     ];
 
@@ -112,6 +119,9 @@ export class SteamButton extends FloatElement {
     btnClass() {
         const r: {[key: string]: boolean} = {btn_small: true};
         r[`btn_${this.type}_innerfade`] = true;
+        if (this.disabled) {
+            r.btn_disabled = true;
+        }
         return classMap(r);
     }
 

--- a/src/lib/components/trade_offers/better_tracking.ts
+++ b/src/lib/components/trade_offers/better_tracking.ts
@@ -8,7 +8,7 @@ import {state} from 'lit/decorators.js';
 import {FetchPendingTrades} from '../../bridge/handlers/fetch_pending_trades';
 import {HasPermissions} from '../../bridge/handlers/has_permissions';
 import {PingSetupExtension} from '../../bridge/handlers/ping_setup_extension';
-import { isFirefox } from '../../utils/detect';
+import {isFirefox} from '../../utils/detect';
 
 @CustomElement()
 @InjectAfter(
@@ -57,8 +57,8 @@ export class BetterTrackingWidget extends FloatElement {
     steamButton() {
         return {
             text: this.isFirefox ? 'Enable in the Extension Popup' : 'Enable',
-            type: this.isFirefox ? 'grey_white' : "green_white",
-            disabled: this.isFirefox
+            type: this.isFirefox ? 'grey_white' : 'green_white',
+            disabled: this.isFirefox,
         };
     }
 
@@ -104,7 +104,12 @@ export class BetterTrackingWidget extends FloatElement {
                           <span class="item-name">Setup Offer Tracking on CSFloat</span>
                           <div class="sale-info">Verify trades while preserving your privacy.</div>
                       </div>
-                      <csfloat-steam-button id="csfloat-enable-enhanced" .text="${this.steamButton().text}" .type="${this.steamButton().type}" .disabled=${this.steamButton().disabled}></csfloat-steam-button>
+                      <csfloat-steam-button
+                          id="csfloat-enable-enhanced"
+                          .text="${this.steamButton().text}"
+                          .type="${this.steamButton().type}"
+                          .disabled=${this.steamButton().disabled}
+                      ></csfloat-steam-button>
                   </div>
               `
             : html``;

--- a/src/lib/components/trade_offers/better_tracking.ts
+++ b/src/lib/components/trade_offers/better_tracking.ts
@@ -8,6 +8,7 @@ import {state} from 'lit/decorators.js';
 import {FetchPendingTrades} from '../../bridge/handlers/fetch_pending_trades';
 import {HasPermissions} from '../../bridge/handlers/has_permissions';
 import {PingSetupExtension} from '../../bridge/handlers/ping_setup_extension';
+import { isFirefox } from '../../utils/detect';
 
 @CustomElement()
 @InjectAfter(
@@ -17,6 +18,9 @@ import {PingSetupExtension} from '../../bridge/handlers/ping_setup_extension';
 export class BetterTrackingWidget extends FloatElement {
     @state()
     show = false;
+
+    @state()
+    isFirefox = isFirefox();
 
     static styles = [
         ...FloatElement.styles,
@@ -49,6 +53,14 @@ export class BetterTrackingWidget extends FloatElement {
             }
         `,
     ];
+
+    steamButton() {
+        return {
+            text: this.isFirefox ? 'Enable in the Extension Popup' : 'Enable',
+            type: this.isFirefox ? 'grey_white' : "green_white",
+            disabled: this.isFirefox
+        };
+    }
 
     async connectedCallback() {
         super.connectedCallback();
@@ -92,7 +104,7 @@ export class BetterTrackingWidget extends FloatElement {
                           <span class="item-name">Setup Offer Tracking on CSFloat</span>
                           <div class="sale-info">Verify trades while preserving your privacy.</div>
                       </div>
-                      <csfloat-steam-button id="csfloat-enable-enhanced" .text="${'Enable'}"></csfloat-steam-button>
+                      <csfloat-steam-button id="csfloat-enable-enhanced" .text="${this.steamButton().text}" .type="${this.steamButton().type}" .disabled=${this.steamButton().disabled}></csfloat-steam-button>
                   </div>
               `
             : html``;

--- a/src/lib/page_scripts/trade_offers.ts
+++ b/src/lib/page_scripts/trade_offers.ts
@@ -7,6 +7,7 @@ import {PingSetupExtension} from '../bridge/handlers/ping_setup_extension';
 import {PingExtensionStatus} from '../bridge/handlers/ping_extension_status';
 import {FetchSteamTrades, FetchSteamTradesResponse} from '../bridge/handlers/fetch_steam_trades';
 import {convertSteamID32To64, getUserSteamID} from '../utils/userinfo';
+import { isFirefox } from '../utils/detect';
 
 init('src/lib/page_scripts/trade_offers.js', main);
 
@@ -112,6 +113,10 @@ if (!inPageContext()) {
         }
 
         btn.addEventListener('click', async () => {
+            if (isFirefox()) {
+                alert('Please enable the feature in the extension popup');
+                return;
+            }
             chrome.runtime.sendMessage(
                 {
                     message: 'requestPermissions',

--- a/src/lib/page_scripts/trade_offers.ts
+++ b/src/lib/page_scripts/trade_offers.ts
@@ -7,7 +7,7 @@ import {PingSetupExtension} from '../bridge/handlers/ping_setup_extension';
 import {PingExtensionStatus} from '../bridge/handlers/ping_extension_status';
 import {FetchSteamTrades, FetchSteamTradesResponse} from '../bridge/handlers/fetch_steam_trades';
 import {convertSteamID32To64, getUserSteamID} from '../utils/userinfo';
-import { isFirefox } from '../utils/detect';
+import {isFirefox} from '../utils/detect';
 
 init('src/lib/page_scripts/trade_offers.js', main);
 

--- a/src/lib/page_scripts/trade_offers.ts
+++ b/src/lib/page_scripts/trade_offers.ts
@@ -114,7 +114,7 @@ if (!inPageContext()) {
 
         btn.addEventListener('click', async () => {
             if (isFirefox()) {
-                alert('Please enable the feature in the extension popup');
+                alert('Please enable the feature in the extension popup in the top right of your browser');
                 return;
             }
             chrome.runtime.sendMessage(

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -35,6 +35,8 @@
             }
             button:disabled {
                 cursor: not-allowed;
+                background-color: rgba(255, 255, 255, .12);
+                color: rgba(255, 255, 255, .5);
             }
         </style>
     </head>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body {
+            width: 300px;
+            padding: 16px;
+            font-family: Arial, sans-serif;
+        }
+        button {
+            width: 100%;
+            padding: 10px;
+            background-color: #4CAF50;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        button:hover {
+            background-color: #45a049;
+        }
+    </style>
+</head>
+<body>
+    <button id="requestPermissions">Grant Required Permissions</button>
+    <script src="popup/popup.js"></script>
+</body>
+</html>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -59,7 +59,7 @@
                 <path d="M12 8v4" />
                 <path d="M12 16h.01" />
             </svg>
-            <span>Grant Required Permissions</span>
+            <span>Enable Offer Tracking</span>
         </button>
         <script src="popup/popup.js"></script>
     </body>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -1,29 +1,64 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="UTF-8">
-    <style>
-        body {
-            width: 300px;
-            padding: 16px;
-            font-family: Arial, sans-serif;
-        }
-        button {
-            width: 100%;
-            padding: 10px;
-            background-color: #4CAF50;
-            color: white;
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-        }
-        button:hover {
-            background-color: #45a049;
-        }
-    </style>
-</head>
-<body>
-    <button id="requestPermissions">Grant Required Permissions</button>
-    <script src="popup/popup.js"></script>
-</body>
+    <head>
+        <meta charset="UTF-8" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Roboto:ital,wght@0,100..900;1,100..900&display=swap"
+            rel="stylesheet"
+        />
+        <style>
+            body {
+                width: 300px;
+                padding: 16px;
+                background-color: #15171c;
+            }
+            button {
+                width: 100%;
+                padding: 10px;
+                background-color: rgba(35, 123, 255, 0.15);
+                color: #237bff;
+                border: none;
+                border-radius: 8px;
+                cursor: pointer;
+                font-family: 'Roboto', serif;
+                font-size: 14px;
+                font-weight: 500;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                gap: 8px;
+            }
+            button:hover {
+                background-color: #2a374d;
+            }
+            button:disabled {
+                cursor: not-allowed;
+            }
+        </style>
+    </head>
+    <body>
+        <button id="requestPermissions">
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+            >
+                <path
+                    d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+                />
+                <path d="M12 8v4" />
+                <path d="M12 16h.01" />
+            </svg>
+            <span>Grant Required Permissions</span>
+        </button>
+        <script src="popup/popup.js"></script>
+    </body>
 </html>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -1,10 +1,25 @@
-document.getElementById('requestPermissions')?.addEventListener('click', async () => {
-    try {
-        const success = await chrome.permissions.request({
-            origins: ['*://*.steampowered.com/*']
+window.addEventListener('DOMContentLoaded', async () => {
+    const requestButton = document.getElementById('requestPermissions');
+    if (!requestButton) {
+        return;
+    }
+
+    const hasPermissions = await chrome.permissions.contains({
+        origins: ['*://*.steampowered.com/*']
+    });
+    if (hasPermissions) {
+        requestButton.children[1].textContent = 'Permissions already granted';
+        requestButton.setAttribute('disabled', 'true');
+    } else {
+        requestButton.addEventListener('click', async () => {
+            try {
+                const success = await chrome.permissions.request({
+                    origins: ['*://*.steampowered.com/*']
+                });
+                console.log('Requested permissions:', success);
+            } catch (error) {
+                console.error('Error requesting permissions:', error);
+            }
         });
-        console.log('Requested permissions:', success);
-    } catch (error) {
-        console.error('Error requesting permissions:', error);
     }
 });

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -1,0 +1,10 @@
+document.getElementById('requestPermissions')?.addEventListener('click', async () => {
+    try {
+        const success = await chrome.permissions.request({
+            origins: ['*://*.steampowered.com/*']
+        });
+        console.log('Requested permissions:', success);
+    } catch (error) {
+        console.error('Error requesting permissions:', error);
+    }
+});

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -5,7 +5,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     }
 
     const hasPermissions = await chrome.permissions.contains({
-        origins: ['*://*.steampowered.com/*']
+        origins: ['*://*.steampowered.com/*'],
     });
 
     if (hasPermissions) {
@@ -16,7 +16,7 @@ window.addEventListener('DOMContentLoaded', async () => {
         requestButton.addEventListener('click', async () => {
             try {
                 const success = await chrome.permissions.request({
-                    origins: ['*://*.steampowered.com/*']
+                    origins: ['*://*.steampowered.com/*'],
                 });
                 if (success) {
                     // extension requires reload to apply permissions

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -7,7 +7,9 @@ window.addEventListener('DOMContentLoaded', async () => {
     const hasPermissions = await chrome.permissions.contains({
         origins: ['*://*.steampowered.com/*']
     });
+
     if (hasPermissions) {
+        // If permissions are already granted, disable the button
         requestButton.children[1].textContent = 'Permissions already granted';
         requestButton.setAttribute('disabled', 'true');
     } else {
@@ -16,7 +18,10 @@ window.addEventListener('DOMContentLoaded', async () => {
                 const success = await chrome.permissions.request({
                     origins: ['*://*.steampowered.com/*']
                 });
-                console.log('Requested permissions:', success);
+                if (success) {
+                    // extension requires reload to apply permissions
+                    browser.runtime.reload();
+                }
             } catch (error) {
                 console.error('Error requesting permissions:', error);
             }

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -10,7 +10,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     if (hasPermissions) {
         // If permissions are already granted, disable the button
-        requestButton.children[1].textContent = 'Permissions already granted';
+        requestButton.children[1].textContent = 'Offer Tracking Enabled';
         requestButton.setAttribute('disabled', 'true');
     } else {
         requestButton.addEventListener('click', async () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,13 +21,16 @@ function getPathEntries(path) {
 
 function convertToFirefoxManifest(manifest) {
     const cp = Object.assign({}, manifest);
+    cp.action = {
+		default_popup: "src/popup.html"
+    }
     cp.background = {
         page: 'src/background_ff.html',
     };
     cp.browser_specific_settings = {
         gecko: {
             id: '{194d0dc6-7ada-41c6-88b8-95d7636fe43c}',
-            strict_min_version: '109.0',
+            strict_min_version: '127.0',
         },
     };
     // Allow getting the extension version from CSFloat page in Firefox
@@ -36,6 +39,7 @@ function convertToFirefoxManifest(manifest) {
         js: ['src/lib/page_scripts/csfloat.js'],
     });
     cp.host_permissions.push('*://*.csfloat.com/*');
+    cp.host_permissions.push('*://*.steampowered.com/*');
     return cp;
 }
 
@@ -48,6 +52,7 @@ module.exports = (env) => {
             getPathEntries('./src/lib/page_scripts/*.ts'),
             getPathEntries('./src/lib/types/*.d.ts'),
             getPathEntries('./src/background.ts'),
+            getPathEntries('./src/popup/popup.ts'),
             getPathEntries('./src/**/*.js')
         ),
         output: {
@@ -97,6 +102,7 @@ module.exports = (env) => {
                     {from: 'src/steamcommunity_ruleset.json', to: 'src/', context: '.'},
                     {from: 'src', to: 'raw/', context: '.'},
                     {from: 'README.md', to: '', context: '.'},
+                    {from: 'src/popup/popup.html', to: 'src/', context: '.'},
                     {
                         from: 'manifest.json',
                         to: 'manifest.json',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,8 @@ function convertToFirefoxManifest(manifest) {
         js: ['src/lib/page_scripts/csfloat.js'],
     });
     cp.host_permissions.push('*://*.csfloat.com/*');
+    // Force optional host permissions to be required
+    cp.host_permissions = cp.host_permissions.concat(cp.optional_host_permissions);
     return cp;
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,6 @@ function convertToFirefoxManifest(manifest) {
         js: ['src/lib/page_scripts/csfloat.js'],
     });
     cp.host_permissions.push('*://*.csfloat.com/*');
-    cp.host_permissions.push('*://*.steampowered.com/*');
     return cp;
 }
 


### PR DESCRIPTION
## Motivation

Fixes #243.

## Description

With this PR we want to start supporting **Firefox**-based browsers for the new versions of the extension again. To achieve this, this PR changes:
- New **popup** exclusive to the Firefox version to provide an option of requesting the required Steam permissions as the BetterTracking-widget doesn't work in Firefox
- Adjust declarativeNetRequest-rules according to Firefox's random IDs
- Change minimum Firefox version to 127.0 to guarantee permissions listed in `host_permissions` are granted on install (source: https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide/)
- Chore: update `@types/chrome` to `0.0.300` to successfully use async/await on `chrome.permissions`-methods

Possible TODOs:
- Adjust the BetterTracking "Enable"-button for Firefox to refer to the popup (automatic opening not possible in Firefox)
- Further popup features: 
  - Error state for popup in case of a permission deny
  - More detailed permission status
  - Explanatory text / links / CSFloat socials 

## Screenshots

Popup with missing permissions:
![image](https://github.com/user-attachments/assets/64983537-0616-4d89-a408-4b5b45acaf87)
Popup with granted permissons:
![image](https://github.com/user-attachments/assets/2786713d-17b7-4a57-8969-187321c55e71)