### PR TITLE
Fix: Blue Percentage on Five-SeveN Heat Treated

### DIFF
--- a/src/lib/bridge/handlers/fetch_bluegem.ts
+++ b/src/lib/bridge/handlers/fetch_bluegem.ts
@@ -46,11 +46,15 @@ export const FetchBluegem = new SimpleHandler<FetchBluegemRequest, FetchBluegemR
             }
         }
 
-        const type = itemInfo.weapon_type.replace(' ', '_');
         const paintseed = itemInfo.paintseed;
+        let type = itemInfo.weapon_type;
+        // Add pattern name to distinguish the Five-SeveNs
+        if (itemInfo.paintindex === 831) {
+            type += ' Heat Treated';
+        }
 
         // Be careful to check if the type exists
-        const patternData = bluegemCache[type]?.[paintseed];
+        const patternData = bluegemCache[type.replace(/ /g, '_')]?.[paintseed];
         if (!patternData) {
             return undefined;
         }


### PR DESCRIPTION
## Description

This PR fixes a bug related to the Fiven-SeveN Heat Treated, which caused a mix-up with the Five-SeveN Case Hardened.

## Screenshot
Before (correct for Five-SeveN CH):
![image](https://github.com/user-attachments/assets/d81e8161-afa1-4832-acf6-96dc67ec261b)
After:
![image](https://github.com/user-attachments/assets/a0bb0dbe-7b59-4636-858b-a4baa5d690c5)
