### PR TITLE
Gradients for Acid / Amber Fades

### DIFF
--- a/src/lib/components/common/item_holder_metadata.ts
+++ b/src/lib/components/common/item_holder_metadata.ts
@@ -32,11 +32,22 @@ export abstract class ItemHolderMetadata extends FloatElement {
                 font-size: 12px;
             }
 
-            .fade {
-                background: -webkit-linear-gradient(0deg, #d9bba5 0%, #e5903b 33%, #db5977 66%, #6775e1 100%);
+            .fade-base {
                 -webkit-background-clip: text;
                 background-clip: text;
                 -webkit-text-fill-color: transparent;
+            }
+
+            .fade {
+                background-image: -webkit-linear-gradient(0deg, #d9bba5 0%, #e5903b 33%, #db5977 66%, #6775e1 100%);
+            }
+
+            .amber-fade {
+                background-image: -webkit-linear-gradient(0deg, #627d66 0%, #896944 50%, #7e4201 100%);
+            }
+
+            .acid-fade {
+                background-image: -webkit-linear-gradient(0deg, #2b441b 0%, #3e6b2f 11%, #82a64a 66%, #c1a16c 100%);
             }
 
             .csfloat-shine-fade-text {
@@ -81,7 +92,8 @@ export abstract class ItemHolderMetadata extends FloatElement {
         if (!this.itemInfo || !this.asset) return html``;
 
         if (isSkin(this.asset)) {
-            const fadePercentage = this.asset && getFadePercentage(this.asset, this.itemInfo);
+            const fadeDetails = this.asset && getFadePercentage(this.asset, this.itemInfo);
+            const {percentage: fadePercentage, fadeType} = fadeDetails ?? {};
 
             if (fadePercentage === 100) {
                 $J(this).parent().addClass('full-fade-border');
@@ -94,8 +106,9 @@ export abstract class ItemHolderMetadata extends FloatElement {
                     <span class="float">${formatFloatWithRank(this.itemInfo, 6)}</span>
                     <span class="seed">
                         ${formatSeed(this.itemInfo)}
-                        ${fadePercentage !== undefined
-                            ? html`<span class="fade ${rank && rank <= 5 ? 'csfloat-shine-fade-text' : ''}"
+                        ${fadeDetails !== undefined && fadePercentage !== undefined
+                            ? html`<span
+                                  class="fade-base ${fadeType} ${rank && rank <= 5 ? 'csfloat-shine-fade-text' : ''}"
                                   >(${floor(fadePercentage, 1)}%)</span
                               >`
                             : nothing}

--- a/src/lib/components/common/item_holder_metadata.ts
+++ b/src/lib/components/common/item_holder_metadata.ts
@@ -93,9 +93,8 @@ export abstract class ItemHolderMetadata extends FloatElement {
 
         if (isSkin(this.asset)) {
             const fadeDetails = this.asset && getFadePercentage(this.asset, this.itemInfo);
-            const {percentage: fadePercentage, fadeType} = fadeDetails ?? {};
 
-            if (fadePercentage === 100) {
+            if (fadeDetails?.percentage === 100) {
                 $J(this).parent().addClass('full-fade-border');
             }
 
@@ -106,10 +105,12 @@ export abstract class ItemHolderMetadata extends FloatElement {
                     <span class="float">${formatFloatWithRank(this.itemInfo, 6)}</span>
                     <span class="seed">
                         ${formatSeed(this.itemInfo)}
-                        ${fadeDetails !== undefined && fadePercentage !== undefined
+                        ${fadeDetails !== undefined
                             ? html`<span
-                                  class="fade-base ${fadeType} ${rank && rank <= 5 ? 'csfloat-shine-fade-text' : ''}"
-                                  >(${floor(fadePercentage, 1)}%)</span
+                                  class="fade-base ${fadeDetails.className} ${rank && rank <= 5
+                                      ? 'csfloat-shine-fade-text'
+                                      : ''}"
+                                  >(${floor(fadeDetails.percentage, 1)}%)</span
                               >`
                             : nothing}
                         ${this.bluegemData

--- a/src/lib/components/inventory/selected_item_info.ts
+++ b/src/lib/components/inventory/selected_item_info.ts
@@ -115,7 +115,7 @@ export class SelectedItemInfo extends FloatElement {
             containerChildren.push(html`<div>Paint Seed: ${formatSeed(this.itemInfo)}</div>`);
 
             // Fade skins
-            const fadePercentage = getFadePercentage(this.asset.description, this.itemInfo);
+            const fadePercentage = getFadePercentage(this.asset.description, this.itemInfo)?.percentage;
             if (fadePercentage !== undefined) {
                 containerChildren.push(html`<div>Fade: ${floor(fadePercentage, 5)}%</div>`);
             }

--- a/src/lib/components/market/item_row_wrapper.ts
+++ b/src/lib/components/market/item_row_wrapper.ts
@@ -222,7 +222,7 @@ export class ItemRowWrapper extends FloatElement {
         }
 
         if (this.itemInfo && isSkin(this.asset)) {
-            const fadePercentage = this.asset && getFadePercentage(this.asset, this.itemInfo);
+            const fadePercentage = this.asset && getFadePercentage(this.asset, this.itemInfo)?.percentage;
 
             return html`
                 <div class="float-row-wrapper">

--- a/src/lib/components/market/sort_listings.ts
+++ b/src/lib/components/market/sort_listings.ts
@@ -129,7 +129,7 @@ export class SortListings extends FloatElement {
                     info,
                     listingId: listingId!,
                     converted_price: listingInfo?.converted_price || 0,
-                    fadePercentage: (asset && getFadePercentage(asset, info)) || 0,
+                    fadePercentage: (asset && getFadePercentage(asset, info)?.percentage) || 0,
                 };
             });
 

--- a/src/lib/components/market/sort_listings.ts
+++ b/src/lib/components/market/sort_listings.ts
@@ -6,7 +6,7 @@ import {state} from 'lit/decorators.js';
 import {gFloatFetcher} from '../../services/float_fetcher';
 import {getMarketInspectLink} from './helpers';
 import {ItemInfo} from '../../bridge/handlers/fetch_inspect_info';
-import {getFadeCalculatorAndSupportedWeapon, getFadePercentage} from '../../utils/skin';
+import {getFadeParams, getFadePercentage} from '../../utils/skin';
 import {AppId, ContextId} from '../../types/steam_constants';
 
 enum SortType {
@@ -39,7 +39,7 @@ export class SortListings extends FloatElement {
 
         const asset = g_rgAssets[AppId.CSGO][ContextId.PRIMARY][listingInfo.asset.id];
 
-        return getFadeCalculatorAndSupportedWeapon(asset) !== undefined;
+        return getFadeParams(asset) !== undefined;
     }
 
     computeButtonText(sortType: SortType): string {

--- a/src/lib/utils/skin.ts
+++ b/src/lib/utils/skin.ts
@@ -165,7 +165,7 @@ export function isBlueSkin(itemInfo: ItemInfo): boolean {
 
 export function getFadeCalculatorAndSupportedWeapon(
     asset: rgAsset
-): [typeof FadeCalculator | typeof AcidFadeCalculator | typeof AmberFadeCalculator, string] | undefined {
+): [typeof FadeCalculator | typeof AcidFadeCalculator | typeof AmberFadeCalculator, string, string] | undefined {
     const FADE_TYPE_TO_CALCULATOR = {
         Fade: FadeCalculator,
         'Acid Fade': AcidFadeCalculator,
@@ -175,19 +175,25 @@ export function getFadeCalculatorAndSupportedWeapon(
     for (const [fadeType, calculator] of Object.entries(FADE_TYPE_TO_CALCULATOR)) {
         for (const supportedWeapon of calculator.getSupportedWeapons()) {
             if (asset.market_hash_name.includes(`${supportedWeapon} | ${fadeType}`)) {
-                return [calculator, supportedWeapon.toString()];
+                return [calculator, supportedWeapon.toString(), fadeType.replace(' ', '-').toLowerCase()];
             }
         }
     }
 }
 
-export function getFadePercentage(asset: rgAsset, itemInfo: ItemInfo): number | undefined {
+export function getFadePercentage(
+    asset: rgAsset,
+    itemInfo: ItemInfo
+): {percentage: number; fadeType: string} | undefined {
     const fadeCalculatorAndSupportedWeapon = getFadeCalculatorAndSupportedWeapon(asset);
 
     if (fadeCalculatorAndSupportedWeapon !== undefined) {
-        const [calculator, supportedWeapon] = fadeCalculatorAndSupportedWeapon;
+        const [calculator, supportedWeapon, fadeType] = fadeCalculatorAndSupportedWeapon;
 
-        return calculator.getFadePercentage(supportedWeapon, itemInfo.paintseed).percentage;
+        return {
+            percentage: calculator.getFadePercentage(supportedWeapon, itemInfo.paintseed).percentage,
+            fadeType,
+        };
     }
 }
 

--- a/src/lib/utils/skin.ts
+++ b/src/lib/utils/skin.ts
@@ -192,7 +192,7 @@ export function getFadeParams(asset: rgAsset):
 export function getFadePercentage(
     asset: rgAsset,
     itemInfo: ItemInfo
-): {percentage: number; fadeType: string} | undefined {
+): {percentage: number; className: string} | undefined {
     const fadeInfo = getFadeParams(asset);
 
     if (fadeInfo !== undefined) {
@@ -200,7 +200,7 @@ export function getFadePercentage(
 
         return {
             percentage: calculator.getFadePercentage(weaponName, itemInfo.paintseed).percentage,
-            fadeType: className,
+            className,
         };
     }
 }

--- a/src/lib/utils/skin.ts
+++ b/src/lib/utils/skin.ts
@@ -163,9 +163,15 @@ export function isBlueSkin(itemInfo: ItemInfo): boolean {
     );
 }
 
-export function getFadeCalculatorAndSupportedWeapon(
+export function getFadeParams(
     asset: rgAsset
-): [typeof FadeCalculator | typeof AcidFadeCalculator | typeof AmberFadeCalculator, string, string] | undefined {
+):
+    | {
+          calculator: typeof FadeCalculator | typeof AcidFadeCalculator | typeof AmberFadeCalculator;
+          weaponName: string;
+          className: string;
+      }
+    | undefined {
     const FADE_TYPE_TO_CALCULATOR = {
         Fade: FadeCalculator,
         'Acid Fade': AcidFadeCalculator,
@@ -175,7 +181,11 @@ export function getFadeCalculatorAndSupportedWeapon(
     for (const [fadeType, calculator] of Object.entries(FADE_TYPE_TO_CALCULATOR)) {
         for (const supportedWeapon of calculator.getSupportedWeapons()) {
             if (asset.market_hash_name.includes(`${supportedWeapon} | ${fadeType}`)) {
-                return [calculator, supportedWeapon.toString(), fadeType.replace(' ', '-').toLowerCase()];
+                return {
+                    calculator,
+                    weaponName: supportedWeapon.toString(),
+                    className: fadeType.replace(' ', '-').toLowerCase(),
+                };
             }
         }
     }
@@ -185,14 +195,14 @@ export function getFadePercentage(
     asset: rgAsset,
     itemInfo: ItemInfo
 ): {percentage: number; fadeType: string} | undefined {
-    const fadeCalculatorAndSupportedWeapon = getFadeCalculatorAndSupportedWeapon(asset);
+    const fadeInfo = getFadeParams(asset);
 
-    if (fadeCalculatorAndSupportedWeapon !== undefined) {
-        const [calculator, supportedWeapon, fadeType] = fadeCalculatorAndSupportedWeapon;
+    if (fadeInfo !== undefined) {
+        const {calculator, weaponName, className} = fadeInfo;
 
         return {
-            percentage: calculator.getFadePercentage(supportedWeapon, itemInfo.paintseed).percentage,
-            fadeType,
+            percentage: calculator.getFadePercentage(weaponName, itemInfo.paintseed).percentage,
+            fadeType: className,
         };
     }
 }

--- a/src/lib/utils/skin.ts
+++ b/src/lib/utils/skin.ts
@@ -163,9 +163,7 @@ export function isBlueSkin(itemInfo: ItemInfo): boolean {
     );
 }
 
-export function getFadeParams(
-    asset: rgAsset
-):
+export function getFadeParams(asset: rgAsset):
     | {
           calculator: typeof FadeCalculator | typeof AcidFadeCalculator | typeof AmberFadeCalculator;
           weaponName: string;


### PR DESCRIPTION
## Description

This PR adds new gradients for the different types of already supported fade skins (i.e. Acid Fade & Amber Fade). Until now they used the typical fade gradient, which of course doesn't reflect their actual color scheme.
The new gradients are similar to the ones added to the website, but adapted for better visibility considering Steam's dark background and theme.

## Screenshots
Old gradients:
<img width="211" alt="Screenshot 2025-03-28 at 13 22 11" src="https://github.com/user-attachments/assets/a4b06f0d-8757-415a-b227-8bf4d6106bf1" />
New gradients:
<img width="211" alt="Screenshot 2025-03-28 at 13 22 11" src="https://github.com/user-attachments/assets/59584265-ade9-4bcf-9b87-fbd39d4305b4" />
