### PR TITLE
Allows Manually Running Submit Workflows

### DIFF
--- a/.github/workflows/submit_chrome.yml
+++ b/.github/workflows/submit_chrome.yml
@@ -4,6 +4,8 @@ on:
         workflows: ["Extension Release"]
         types:
             - completed
+    # Allow manual triggering from the GitHub Actions UI
+    workflow_dispatch:
 
 jobs:
     submit:

--- a/.github/workflows/submit_firefox.yml
+++ b/.github/workflows/submit_firefox.yml
@@ -4,6 +4,8 @@ on:
         workflows: ["Extension Release"]
         types:
             - completed
+    # Allow manual triggering from the GitHub Actions UI
+    workflow_dispatch:
 
 jobs:
     submit:


### PR DESCRIPTION
To facilitate running the FF release that previously failed.