### PR TITLE
Fix: Release Note for Firefox

### DIFF
--- a/.github/workflows/submit_firefox.yml
+++ b/.github/workflows/submit_firefox.yml
@@ -42,5 +42,7 @@ jobs:
             approval-note: |
               The source code and build instructions are available at 
               https://github.com/csfloat/extension?tab=readme-ov-file#how-to-build-release.
+            release-note: |
+              Learn more about this release and its changes from the latest [Github release](https://github.com/csfloat/extension/releases).
             auth-api-issuer: ${{ secrets.AUTH_API_ISSUER }}
             auth-api-secret: ${{ secrets.AUTH_API_SECRET }}

--- a/.github/workflows/submit_firefox.yml
+++ b/.github/workflows/submit_firefox.yml
@@ -19,6 +19,7 @@ jobs:
             zip -r extension-source.zip .
 
         - name: Download Release Assets
+          id: download-release
           uses: robinraju/release-downloader@v1
           with:
             latest: true # Download the latest release
@@ -43,6 +44,6 @@ jobs:
               The source code and build instructions are available at 
               https://github.com/csfloat/extension?tab=readme-ov-file#how-to-build-release.
             release-note: |
-              Learn more about this release and its changes from the latest [Github release](https://github.com/csfloat/extension/releases).
+              Learn more about release ${{ steps.download-release.outputs.release_name }} by visiting the [GitHub Release](https://github.com/csfloat/extension/releases/tag/${{ steps.download-release.outputs.tag_name }}).
             auth-api-issuer: ${{ secrets.AUTH_API_ISSUER }}
             auth-api-secret: ${{ secrets.AUTH_API_SECRET }}


### PR DESCRIPTION
## Motivation

For successful extension releases via workflow on Firefox, we have to include a release note.

## Description

This PR adds a generic release note to the submit workflow for the Firefox extension.
The note links to the Github releases page to avoid copy-pasting the content of the release to the Firefox Store.