### PR TITLE
Fix: Handle Pagination for Conflicting Elements

### DIFF
--- a/src/lib/components/market/item_row_wrapper.ts
+++ b/src/lib/components/market/item_row_wrapper.ts
@@ -23,7 +23,8 @@ import {ConflictingExtension, ConflictingMode, HideConflictingElement, StyleConf
 @InjectAppend('#searchResultsRows .market_listing_row .market_listing_item_name_block', InjectionMode.CONTINUOUS)
 @HideConflictingElement(
     ConflictingExtension.CS2_TRADER,
-    '#searchResultsRows .market_listing_row .stickerHolderMarket, #searchResultsRows .market_listing_row .stickersTotal, #searchResultsRows .market_listing_row .floatBarMarket'
+    '#searchResultsRows .market_listing_row .stickerHolderMarket, #searchResultsRows .market_listing_row .stickersTotal, #searchResultsRows .market_listing_row .floatBarMarket',
+    ConflictingMode.CONTINUOUS
 )
 @HideConflictingElement(
     ConflictingExtension.SIH,


### PR DESCRIPTION
## Motivation

Currently, the hiding of conflicting extension elements doesn't work well with Steam's pagination on item pages on the market.

## Description

This PR changes the conflicting element detection for CS2Trader to `CONTINUOUS` to be able to hide elements again after the user switches to a different page.

## Reproduction steps

- enable the CSFloat extension as well as CS2Trader
- go to the Steam market and open any weapon skin page (for example AK Vulcan FT)
- navigate to page 2 of the listings
- other extensions will insert themselves again, convoluting the page