### PR TITLE
Shows Offer Tracking Banner in More Scenarios

### DIFF
--- a/src/lib/components/trade_offers/better_tracking.ts
+++ b/src/lib/components/trade_offers/better_tracking.ts
@@ -78,7 +78,10 @@ export class BetterTrackingWidget extends FloatElement {
                 return;
             }
 
-            const trades = await ClientSend(FetchPendingTrades, {state: 'queued,pending,verified', limit: 1});
+            const trades = await ClientSend(FetchPendingTrades, {
+                state: 'queued,pending,verified,failed,cancelled',
+                limit: 1,
+            });
             if (trades.count === 0) {
                 // They aren't actively using CSFloat Market, no need to show this
                 return;


### PR DESCRIPTION
If they have only had a cancelled or failed sale, still show the banner since this is generating support tickets of people asking why they can't enable offer tracking.