### PR TITLE
Adds MIT License to Firefox Publish Workflow

### DIFF
--- a/.github/workflows/submit_firefox.yml
+++ b/.github/workflows/submit_firefox.yml
@@ -40,6 +40,7 @@ jobs:
             addon-id: ${{ secrets.FIREFOX_EXTENSION_ID }}
             addon-path: ${{ steps.find-path.outputs.firefox_extension_path }}
             source-path: "extension-source.zip"
+            license: "MIT"
             approval-note: |
               The source code and build instructions are available at 
               https://github.com/csfloat/extension?tab=readme-ov-file#how-to-build-release.


### PR DESCRIPTION
`Error: Failed to PATCH https://addons.mozilla.org/api/v5/addons/addon/***/versions/5.5.0/: 400 Bad Request {"license":["License with slug=undefined does not exist."]}`