### PR TITLE
Fix: persist listing sort order between page navigations

### DIFF
--- a/src/lib/components/market/sort_listings.ts
+++ b/src/lib/components/market/sort_listings.ts
@@ -9,6 +9,7 @@ import {ItemInfo} from '../../bridge/handlers/fetch_inspect_info';
 import {getFadeParams, getFadePercentage} from '../../utils/skin';
 import {AppId, ContextId} from '../../types/steam_constants';
 import {debounce} from 'lodash-decorators';
+import { DebouncedFunc } from 'lodash';
 
 enum SortType {
     FLOAT = 'Float',
@@ -20,12 +21,6 @@ enum SortDirection {
     ASC,
     DESC,
 }
-
-// Describes a function that has been decorated with a lodash debounce decorator,
-// which adds a .cancel() method to it.
-type CancellableDebounced = {
-    cancel(): void;
-};
 
 @CustomElement()
 export class SortListings extends FloatElement {
@@ -75,7 +70,7 @@ export class SortListings extends FloatElement {
 
         // Workaround to avoid using @ts-ignore:
         // type assertion to inform ts about the .cancel() added from the lodash debounce
-        (this.onMutation as unknown as CancellableDebounced).cancel();
+        (this.onMutation as DebouncedFunc<() => void>).cancel();
     }
 
     /**

--- a/src/lib/components/market/sort_listings.ts
+++ b/src/lib/components/market/sort_listings.ts
@@ -21,6 +21,12 @@ enum SortDirection {
     DESC,
 }
 
+// Describes a function that has been decorated with a lodash debounce decorator,
+// which adds a .cancel() method to it.
+type CancellableDebounced = {
+    cancel(): void;
+};
+
 @CustomElement()
 export class SortListings extends FloatElement {
     @state()
@@ -66,6 +72,10 @@ export class SortListings extends FloatElement {
         if (this.observer) {
             this.observer.disconnect();
         }
+
+        // Workaround to avoid using @ts-ignore:
+        // type assertion to inform ts about the .cancel() added from the lodash debounce
+        (this.onMutation as unknown as CancellableDebounced).cancel();
     }
 
     /**

--- a/src/lib/components/market/sort_listings.ts
+++ b/src/lib/components/market/sort_listings.ts
@@ -53,13 +53,11 @@ export class SortListings extends FloatElement {
         const targetNode = document.getElementById('searchResultsRows');
         if (!targetNode) return;
 
-        const config = {childList: true};
-
         // Create a MutationObserver to detect when the page's items are dynamically replaced.
         this.observer = new MutationObserver(() => this.onMutation());
 
         // Start observing the target node for additions or removals of child elements.
-        this.observer.observe(targetNode, config);
+        this.observer.observe(targetNode, {childList: true});
     }
 
     disconnectedCallback() {
@@ -83,7 +81,6 @@ export class SortListings extends FloatElement {
         if (this.direction === SortDirection.NONE) return;
 
         const targetNode = document.getElementById('searchResultsRows');
-        const config = {childList: true};
 
         // Disconnect the observer temporarily to prevent sortListings() from causing this mutation
         // handler to re-trigger, causing a loop.
@@ -94,7 +91,7 @@ export class SortListings extends FloatElement {
             .finally(() => {
                 // Reconnect the observer to watch for the next page change.
                 if (targetNode) {
-                    this.observer?.observe(targetNode, config);
+                    this.observer?.observe(targetNode, {childList: true});
                 }
             });
     }

--- a/src/lib/components/market/sort_listings.ts
+++ b/src/lib/components/market/sort_listings.ts
@@ -9,7 +9,7 @@ import {ItemInfo} from '../../bridge/handlers/fetch_inspect_info';
 import {getFadeParams, getFadePercentage} from '../../utils/skin';
 import {AppId, ContextId} from '../../types/steam_constants';
 import {debounce} from 'lodash-decorators';
-import { DebouncedFunc } from 'lodash';
+import {DebouncedFunc} from 'lodash';
 
 enum SortType {
     FLOAT = 'Float',


### PR DESCRIPTION
This PR aims to solve this bug https://github.com/csfloat/extension/issues/196 where float/fade sort direction is not persisted between moving through listing result pages. This forces the user to manually re-apply the sort on every single page, which can be annoying.

## **Changes:**
The fix uses a `MutationObserver` within `SortListings` to detect when the page content updates (user navigating to another page) and leverages a debounced handler to re-apply the user's chosen sort order.

A `MutationObserver` is initialized to watch the `#searchResultsRows` container for changes. The component doesn't re-render on page changes, so the MutationObserver is used to reliably detect when new items are loaded into the DOM, allowing us to trigger the re-sort logic.

The `onMutation` handler is debounced to ensure the function runs only once after all DOM changes have settled.

To prevent potential infinite loops, the onMutation handler disconnects the observer before modifying the DOM and reconnects it after the sorting is complete.


https://github.com/user-attachments/assets/892aa465-2b20-40f5-90de-a2aaa3bd4b45


## **Testing:**
No build/run errors
Linter is happy
<img width="1137" alt="Screenshot 2025-06-11 at 5 12 48 PM" src="https://github.com/user-attachments/assets/6d7957fd-574a-4977-9088-48dbfe512dea" />
