### PR TITLE
Fix: Limit Item Info Injection to Appid 730

### DIFF
--- a/src/lib/components/inventory/selected_item_info.ts
+++ b/src/lib/components/inventory/selected_item_info.ts
@@ -31,8 +31,8 @@ import './list_item_modal';
  * item click.
  */
 @CustomElement()
-@InjectAfter('div#iteminfo0_content .item_desc_description div.item_desc_game_info', InjectionMode.CONTINUOUS)
-@InjectAfter('div#iteminfo1_content .item_desc_description div.item_desc_game_info', InjectionMode.CONTINUOUS)
+@InjectAfter('div.app730#iteminfo0_content .item_desc_description div.item_desc_game_info', InjectionMode.CONTINUOUS)
+@InjectAfter('div.app730#iteminfo1_content .item_desc_description div.item_desc_game_info', InjectionMode.CONTINUOUS)
 export class SelectedItemInfo extends FloatElement {
     static styles = [
         ...FloatElement.styles,


### PR DESCRIPTION
Fixes #334 by limiting the injection of `SelectedItemInfo` to context DOM parents with the `app730` class.