### PR TITLE
[src/lib/filter] Add New Method seedInList

### DIFF
--- a/src/lib/filter/custom_functions.ts
+++ b/src/lib/filter/custom_functions.ts
@@ -23,6 +23,9 @@ export function match(str: string, regex: string) {
     else return 0;
 }
 
-export function seedInList(seed: number, seedList: number[]) {
-    return seedList.includes(seed);
+export function seedInList(seed: string | number, seedList: (string | number)[]) {
+    const numericSeed = Number(seed);
+    const numericList = seedList.map(Number);
+
+    return numericList.includes(numericSeed);
 }

--- a/src/lib/filter/custom_functions.ts
+++ b/src/lib/filter/custom_functions.ts
@@ -25,8 +25,14 @@ export function match(str: string, regex: string) {
 
 export function seedInList(seed: string, seeds: string) {
     if (typeof seeds !== "string") {
-        throw new TypeError(`seedGroup must be a string, got ${typeof seeds}`);
+        throw new TypeError(`seeds must be a string, got ${typeof seeds}`);
     }
+    
+    if (typeof seed !== "string" && typeof seed !== "number") {
+        throw new TypeError(`seed must be a string or number, got ${typeof seed}`);
+    }
+
+    const seedStr = seed.toString();
 
     const seedList = seeds
         .replace(/,/g, ' ')
@@ -34,5 +40,5 @@ export function seedInList(seed: string, seeds: string) {
         .map(s => s.trim())
         .filter(s => s.length);
     
-    return seedList.includes(seed);
+    return seedList.includes(seedStr);
 }

--- a/src/lib/filter/custom_functions.ts
+++ b/src/lib/filter/custom_functions.ts
@@ -24,8 +24,16 @@ export function match(str: string, regex: string) {
 }
 
 export function seedInList(seed: string | number, seedList: (string | number)[]) {
-    const numericSeed = Number(seed);
-    const numericList = seedList.map(Number);
+    if (!Array.isArray(seedList)) {
+        throw new TypeError(`seedList must be an array, got ${typeof seedList}`);
+    }
 
+    const numericSeed = Number(seed);
+    if (Number.isNaN(numericSeed)) return false;
+
+    const numericList = seedList
+        .map(Number)
+        .filter(n => !Number.isNaN(n));
+    
     return numericList.includes(numericSeed);
 }

--- a/src/lib/filter/custom_functions.ts
+++ b/src/lib/filter/custom_functions.ts
@@ -29,7 +29,9 @@ export function seedInList(seed: string, seeds: string) {
     }
 
     const seedList = seeds
+        .replace(/,/g, ' ')
         .split(/\s+/)
+        .map(s => s.trim())
         .filter(s => s.length);
     
     return seedList.includes(seed);

--- a/src/lib/filter/custom_functions.ts
+++ b/src/lib/filter/custom_functions.ts
@@ -22,3 +22,7 @@ export function match(str: string, regex: string) {
     if (thisMatch !== null) return thisMatch.length;
     else return 0;
 }
+
+export function seedInList(seed: number, seedList: number[]) {
+    return seedList.includes(seed);
+}

--- a/src/lib/filter/custom_functions.ts
+++ b/src/lib/filter/custom_functions.ts
@@ -23,17 +23,14 @@ export function match(str: string, regex: string) {
     else return 0;
 }
 
-export function seedInList(seed: string | number, seedList: (string | number)[]) {
-    if (!Array.isArray(seedList)) {
-        throw new TypeError(`seedList must be an array, got ${typeof seedList}`);
+export function seedInList(seed: string, seeds: string) {
+    if (typeof seeds !== "string") {
+        throw new TypeError(`seedGroup must be a string, got ${typeof seeds}`);
     }
 
-    const numericSeed = Number(seed);
-    if (Number.isNaN(numericSeed)) return false;
-
-    const numericList = seedList
-        .map(Number)
-        .filter(n => !Number.isNaN(n));
+    const seedList = seeds
+        .split(/\s+/)
+        .filter(s => s.length);
     
-    return numericList.includes(numericSeed);
+    return seedList.includes(seed);
 }

--- a/src/lib/filter/filter.ts
+++ b/src/lib/filter/filter.ts
@@ -1,5 +1,5 @@
 import {InternalInputVars, SerializedFilter} from './types';
-import {match, percentile, percentileRange} from './custom_functions';
+import {match, percentile, percentileRange, seedInList} from './custom_functions';
 import {compileExpression} from 'filtrex';
 
 type ExpressionRunner = (data: InternalInputVars) => boolean;
@@ -66,6 +66,7 @@ export class Filter {
             match: match,
             percentile: (rank: number) => percentile(this.currentVars!, rank),
             percentileRange: (minRank: number, maxRank: number) => percentileRange(this.currentVars!, minRank, maxRank),
+            seedInList: seedInList,
         };
     }
 


### PR DESCRIPTION
**Summary**
--- 
`seedInList` allows users to filter for items that satisfy a list of paint seeds they are looking for. This is particularly useful for people who are looking for tier1/tier2/tier3 patterns, which each have 30+ paint seeds and can be quite tedious to search for.

E.g. seed == 301 or seed == 625 or ... or seed == 540 gets annoying pretty quick and most people do manual cmd/crtl + f searches or use a custom script.

Examples:
<img width="488" height="206" alt="t1_bayonet_gamma_doppler_p1" src="https://github.com/user-attachments/assets/0a6cdd00-0600-4e42-8265-4888621b2453" />
<img width="476" height="490" alt="snow_leopard_t1" src="https://github.com/user-attachments/assets/377d5438-a651-4ed3-abc7-b7ea324e2fa4" />

**Implementation Details + Demo (ran dev build in chrome)**
---
Most pattern guides for CS2 are made by korenevskiy, and those that aren't mostly follow his formatting. 

I've classified the two most common ways guides list the pattern seeds:

1. seed1 seed2 ... seed10
2. seed1, seed2, ..., seed10

The implementation will allow us to **directly copy and paste the numbers from the images above** and pass it into our new method.

Example One (most common case, seeds separated by seeds):
<img width="659" height="708" alt="demo" src="https://github.com/user-attachments/assets/23d4f64a-f724-46ba-a6f6-393fa10a56dd" />

Example Two (with commas this time):
<img width="637" height="684" alt="demo2" src="https://github.com/user-attachments/assets/fe77383b-e397-48ce-b7b3-833fe8767dcf" />

**Future Work**
---
Once approved, will need to add this method to `filter_help.ts` so users can see and understand how to use this method properly. Can probably find a better name for this method as well so it's more intuitive to users.

Also, this feature would be extremely useful for the csfloat market search filters as well. But I'm not sure how they go about receiving feature ideas from the public.