### PR TITLE
Switches Trade Verification to Use "slim" Endpoint

### DIFF
--- a/src/lib/alarms/blocked_users.ts
+++ b/src/lib/alarms/blocked_users.ts
@@ -1,11 +1,11 @@
-import {Trade} from '../types/float_market';
+import {SlimTrade} from '../types/float_market';
 import {gStore} from '../storage/store';
 import {StorageKey} from '../storage/keys';
 import {FetchSteamUser} from '../bridge/handlers/fetch_steam_user';
 import {FetchBlockedUsers} from '../bridge/handlers/fetch_blocked_users';
 import {PingBlockedUsers} from '../bridge/handlers/ping_blocked_users';
 
-export async function reportBlockedBuyers(pendingTrades: Trade[]) {
+export async function reportBlockedBuyers(pendingTrades: SlimTrade[]) {
     const lastPing = await gStore.getWithStorage<number>(
         chrome.storage.local,
         StorageKey.LAST_TRADE_BLOCKED_PING_ATTEMPT

--- a/src/lib/alarms/csfloat_trade_pings.ts
+++ b/src/lib/alarms/csfloat_trade_pings.ts
@@ -1,5 +1,4 @@
-import {Trade} from '../types/float_market';
-import {FetchPendingTrades} from '../bridge/handlers/fetch_pending_trades';
+import {SlimTrade} from '../types/float_market';
 import {pingTradeHistory} from './trade_history';
 import {cancelUnconfirmedTradeOffers, pingCancelTrades, pingSentTradeOffers} from './trade_offer';
 import {HasPermissions} from '../bridge/handlers/has_permissions';
@@ -10,6 +9,7 @@ import {StorageKey} from '../storage/keys';
 import {reportBlockedBuyers} from './blocked_users';
 import {TradeHistoryStatus} from '../bridge/handlers/trade_history_status';
 import {pingRollbackTrades} from './rollback';
+import {FetchSlimTrades} from '../bridge/handlers/fetch_slim_trades';
 
 export const PING_CSFLOAT_TRADE_STATUS_ALARM_NAME = 'ping_csfloat_trade_status_alarm';
 
@@ -28,9 +28,9 @@ export async function pingTradeStatus(expectedSteamID?: string) {
         return;
     }
 
-    let pendingTrades: Trade[];
+    let pendingTrades: SlimTrade[];
     try {
-        const resp = await FetchPendingTrades.handleRequest({limit: 3000, exclude_wait_for_settlement: true}, {});
+        const resp = await FetchSlimTrades.handleRequest({limit: 3000, exclude_wait_for_settlement: true}, {});
         pendingTrades = resp.trades;
     } catch (e) {
         console.error(e);
@@ -75,7 +75,7 @@ interface UpdateErrors {
     rollback_trades_error?: string;
 }
 
-async function pingUpdates(pendingTrades: Trade[]): Promise<UpdateErrors> {
+async function pingUpdates(pendingTrades: SlimTrade[]): Promise<UpdateErrors> {
     const errors: UpdateErrors = {};
 
     try {

--- a/src/lib/alarms/rollback.ts
+++ b/src/lib/alarms/rollback.ts
@@ -1,9 +1,9 @@
-import {Trade, TradeState} from '../types/float_market';
+import {SlimTrade, TradeState} from '../types/float_market';
 import {TradeHistoryStatus} from '../bridge/handlers/trade_history_status';
 import {PingRollbackTrade} from '../bridge/handlers/ping_rollback_trade';
 import {TradeStatus} from '../types/steam_constants';
 
-export async function pingRollbackTrades(pendingTrades: Trade[], tradeHistory: TradeHistoryStatus[]) {
+export async function pingRollbackTrades(pendingTrades: SlimTrade[], tradeHistory: TradeHistoryStatus[]) {
     if (!pendingTrades || pendingTrades.length === 0) {
         return;
     }

--- a/src/lib/alarms/trade_history.ts
+++ b/src/lib/alarms/trade_history.ts
@@ -1,9 +1,9 @@
-import {Trade} from '../types/float_market';
+import {SlimTrade, Trade} from '../types/float_market';
 import {TradeHistoryStatus, TradeHistoryType} from '../bridge/handlers/trade_history_status';
 import {AppId, TradeStatus} from '../types/steam_constants';
 import {clearAccessTokenFromStorage, getAccessToken} from './access_token';
 
-export async function pingTradeHistory(pendingTrades: Trade[]): Promise<TradeHistoryStatus[]> {
+export async function pingTradeHistory(pendingTrades: SlimTrade[]): Promise<TradeHistoryStatus[]> {
     const {history, type} = await getTradeHistory();
 
     // premature optimization in case it's 100 trades

--- a/src/lib/alarms/trade_offer.ts
+++ b/src/lib/alarms/trade_offer.ts
@@ -1,5 +1,5 @@
 import {TradeOfferState, TradeStatus} from '../types/steam_constants';
-import {Trade, TradeState} from '../types/float_market';
+import {SlimTrade, TradeState} from '../types/float_market';
 import {OfferStatus, TradeOfferStatus, TradeOffersType} from '../bridge/handlers/trade_offer_status';
 import {clearAccessTokenFromStorage, getAccessToken} from './access_token';
 import {AnnotateOffer} from '../bridge/handlers/annotate_offer';
@@ -11,7 +11,7 @@ import {HasPermissions} from '../bridge/handlers/has_permissions';
 import {convertSteamID32To64} from '../utils/userinfo';
 import {TradeHistoryStatus} from '../bridge/handlers/trade_history_status';
 
-export async function pingSentTradeOffers(pendingTrades: Trade[]) {
+export async function pingSentTradeOffers(pendingTrades: SlimTrade[]) {
     const {offers, type} = await getSentTradeOffers();
 
     const offersToFind = pendingTrades.reduce(
@@ -68,7 +68,7 @@ export async function pingSentTradeOffers(pendingTrades: Trade[]) {
     }
 }
 
-export async function pingCancelTrades(pendingTrades: Trade[], tradeHistory: TradeHistoryStatus[]) {
+export async function pingCancelTrades(pendingTrades: SlimTrade[], tradeHistory: TradeHistoryStatus[]) {
     const hasWaitForCancelPing = pendingTrades.find((e) => e.state === TradeState.PENDING && e.wait_for_cancel_ping);
     if (!hasWaitForCancelPing) {
         // Nothing to process/ping, exit
@@ -119,7 +119,7 @@ export async function pingCancelTrades(pendingTrades: Trade[], tradeHistory: Tra
 
 // cancelUnconfirmedTradeOffers related to sales on CSFloat that haven't been confirmed for a while
 // Helps prevent the user from sending a trade offer _way after_ the sale has already failed
-export async function cancelUnconfirmedTradeOffers(pendingTrades: Trade[]) {
+export async function cancelUnconfirmedTradeOffers(pendingTrades: SlimTrade[]) {
     const offerIDsToCancel = [
         ...new Set(
             pendingTrades

--- a/src/lib/bridge/handlers/fetch_slim_trades.ts
+++ b/src/lib/bridge/handlers/fetch_slim_trades.ts
@@ -7,7 +7,6 @@ export interface FetchSlimTradesRequest {
     state?: string;
     limit?: number;
     page?: number;
-    exclude_wait_for_settlement?: boolean;
 }
 
 export interface FetchSlimTradesResponse {
@@ -21,7 +20,7 @@ export const FetchSlimTrades = new SimpleHandler<FetchSlimTradesRequest, FetchSl
         const state = req.state ? req.state : 'pending';
         const limit = req.limit ? req.limit : 100;
         const resp = await fetch(
-            `${environment.csfloat_base_api_url}/v1/me/trades/slim?state=${state}&limit=${limit}&exclude_wait_for_settlement=${req.exclude_wait_for_settlement || false}&page=${req.page || 0}`,
+            `${environment.csfloat_base_api_url}/v1/me/trades/slim?state=${state}&limit=${limit}&page=${req.page || 0}`,
             {
                 credentials: 'include',
             }

--- a/src/lib/bridge/handlers/fetch_slim_trades.ts
+++ b/src/lib/bridge/handlers/fetch_slim_trades.ts
@@ -1,0 +1,36 @@
+import {SlimTrade} from '../../types/float_market';
+import {SimpleHandler} from './main';
+import {RequestType} from './types';
+import {environment} from '../../../environment';
+
+export interface FetchSlimTradesRequest {
+    state?: string;
+    limit?: number;
+    page?: number;
+    exclude_wait_for_settlement?: boolean;
+}
+
+export interface FetchSlimTradesResponse {
+    count: number;
+    trades: SlimTrade[];
+}
+
+export const FetchSlimTrades = new SimpleHandler<FetchSlimTradesRequest, FetchSlimTradesResponse>(
+    RequestType.FETCH_SLIM_TRADES,
+    async (req) => {
+        const state = req.state ? req.state : 'pending';
+        const limit = req.limit ? req.limit : 100;
+        const resp = await fetch(
+            `${environment.csfloat_base_api_url}/v1/me/trades/slim?state=${state}&limit=${limit}&exclude_wait_for_settlement=${req.exclude_wait_for_settlement || false}&page=${req.page || 0}`,
+            {
+                credentials: 'include',
+            }
+        );
+
+        if (resp.status !== 200) {
+            throw new Error('invalid status');
+        }
+
+        return resp.json() as Promise<FetchSlimTradesResponse>;
+    }
+);

--- a/src/lib/bridge/handlers/handlers.ts
+++ b/src/lib/bridge/handlers/handlers.ts
@@ -32,6 +32,7 @@ import {FetchRecommendedPrice} from './fetch_recommended_price';
 import {FetchCSFloatMe} from './fetch_csfloat_me';
 import {PingRollbackTrade} from './ping_rollback_trade';
 import {FetchTradeHistory} from './fetch_trade_history';
+import {FetchSlimTrades} from './fetch_slim_trades';
 
 export const HANDLERS_MAP: {[key in RequestType]: RequestHandler<any, any>} = {
     [RequestType.EXECUTE_SCRIPT_ON_PAGE]: ExecuteScriptOnPage,
@@ -66,4 +67,5 @@ export const HANDLERS_MAP: {[key in RequestType]: RequestHandler<any, any>} = {
     [RequestType.FETCH_CSFLOAT_ME]: FetchCSFloatMe,
     [RequestType.PING_ROLLBACK_TRADE]: PingRollbackTrade,
     [RequestType.FETCH_TRADE_HISTORY]: FetchTradeHistory,
+    [RequestType.FETCH_SLIM_TRADES]: FetchSlimTrades,
 };

--- a/src/lib/bridge/handlers/types.ts
+++ b/src/lib/bridge/handlers/types.ts
@@ -31,4 +31,5 @@ export enum RequestType {
     FETCH_CSFLOAT_ME = 29,
     PING_ROLLBACK_TRADE = 30,
     FETCH_TRADE_HISTORY = 31,
+    FETCH_SLIM_TRADES = 32,
 }

--- a/src/lib/types/float_market.ts
+++ b/src/lib/types/float_market.ts
@@ -91,6 +91,7 @@ export interface Trade {
     id: string;
     accepted_at?: string;
     buyer: User;
+    seller: User;
     buyer_id: string;
     contract: Contract;
     contract_id: string;
@@ -106,4 +107,17 @@ export interface Trade {
     wait_for_cancel_ping?: boolean;
     seller_blocked_buyer_at?: string;
     buyer_blocked_seller_at?: string;
+}
+
+export interface SlimItem {
+    asset_id: string;
+    market_hash_name: string;
+}
+
+export interface SlimContract {
+    item: SlimItem;
+}
+
+export interface SlimTrade extends Omit<Trade, 'buyer' | 'seller' | 'contract' | 'trade_url'> {
+    contract: SlimContract;
 }


### PR DESCRIPTION
Lower amount of bandwidth wasted by fields that aren't used for verification by switching to the "slim" endpoint.

DO_NOT_SUBMIT=Wait for slim to rollout in production.